### PR TITLE
chore: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,24 @@
+name: Actionlint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  actionlint:
+    name: GitHub Actions Workflow Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          filter_mode: added
+          fail_level: error


### PR DESCRIPTION
## Summary
- Adds an `Actionlint` workflow that validates GitHub Actions workflow files on PRs to `main`
- Uses `reviewdog/action-actionlint@v1` to post inline review comments on lint findings (added lines only, fail on `error`)
- Runs on `ubuntu-latest`

Mirrors the workflow from [`monta-app/service-api-gateways`](https://github.com/monta-app/service-api-gateways/blob/main/.github/workflows/actionlint.yml), with the runner swapped to `ubuntu-latest` since this is a public repo.

## Test plan
- [ ] CI passes on this PR
- [ ] Confirm the actionlint job appears in the PR checks