### PR TITLE
feat: Consolidate Stroohm Terms & Privacy into multi-language docs (EN/FR/NL)

### DIFF
--- a/en-stroohm-privacy-policy.md
+++ b/en-stroohm-privacy-policy.md
@@ -1,62 +1,681 @@
-# STROOHM PRIVACY POLICY
+# Table of Contents
 
-**stroohm.be**, located at Interescautlaan 100 B2.12, 2627 Schelle, is responsible for the processing of personal data as shown in this privacy statement.
+- [STROOHM Privacy Policy (English)](#stroohm-privacy-policy-english)
+- [STROOHM Déclaration de confidentialité (Français)](#stroohm-dclaration-de-confidentialit-franais)
+- [STROOHM Privacyverklaring (Nederlands)](#stroohm-privacyverklaring-nederlands)
 
-## Contact details:
-[https://stroohm.be/](https://stroohm.be/)  
-Interescautlaan 100 B2.12, 2627 Schelle  
-info@stroohm.be  
+---
 
-## Personal data that we process
-stroohm.be processes your personal data because you use our services and/or because you provide them to us yourself. This data can be transferred directly to Stroohm.be or made available to one of our partners under their platform. In the case of the latter situation, we refer to the privacy policy on [https://stroohm.evc-net.com/](https://stroohm.evc-net.com/)
+# STROOHM Privacy Policy (English)
 
-Below you will find an overview of the personal data that we process:
+- **Date:** May 2026
+- **Data Controller:** STROOHM BV
+- **Company Registration No.:** 0716.755.863
+- **Registered Office:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Privacy contact:** privacy@stroohm.com
+- **Platform Operator (independent controller):** Monta ApS – https://app.monta.app/privacy-policy
 
-- First and last name
-- Address details
-- Telephone number
-- Email address
-- Language
-- Type of electrical connection of home
-- Account number
-- Photos
-- Other personal data that you actively provide, for example by creating a profile on this website, in correspondence and by telephone
-- Data about your activities on our website
+> **Scope:** This Privacy Policy applies to the personal data processed by STROOHM BV in the context of its own services (installation, maintenance, customer management). For the processing of personal data by Monta ApS in connection with the charging platform, subscriptions and energy billing, Monta acts as an independent data controller. Please consult Monta’s privacy policy via https://app.monta.app/privacy-policy
 
-## Special and/or sensitive personal data that we process
-Our website and/or service does not intend to collect data about website visitors who are younger than 16 years of age, unless they have permission from their parents or guardian. However, we cannot check whether a visitor is older than 16. We therefore advise parents to be involved in the online activities of their children, in order to prevent data about children being collected without parental consent. If you are convinced that we have collected personal data about a minor without this consent, please contact us via info@stroohm.be, and we will delete this information.
+## 1. Introduction and identity of the data controller
 
-## For what purpose and on what basis do we process personal data?
-stroohm.be processes your personal data for the following purposes (in accordance with article 6 and article 13, 1, c GDPR):
+STROOHM BV (hereinafter “STROOHM”, “we”, “us”) attaches great importance to the protection of your personal data and processes such data with due care, in accordance with the European General Data Protection Regulation (GDPR – Regulation (EU) 2016/679) and applicable Belgian data protection legislation.
 
-- To process your payment
-- To be able to call or email you if this is necessary to carry out our services
-- To deliver goods and services to you
+STROOHM BV acts as data controller for the processing of personal data collected in connection with its own services, including:
 
-stroohm.be also processes personal data if we are legally obliged to do so, such as data that we need for our tax return.
+- Installation and maintenance of charging infrastructure
+- Commercial and administrative customer management
+- Invoicing for installation and management services provided by STROOHM
+- Communication with customers, partners and website visitors
 
-## Automated decision-making
-stroohm.be does not make decisions based on automated processing on matters that can have (significant) consequences for people. This concerns decisions that are made by computer programs or systems, without a human being (for example an employee of stroohm.be) involved.
+STROOHM does not process personal data of end users (EV drivers) in relation to platform usage, charging sessions, subscriptions or energy billing. Such processing falls exclusively under the responsibility of Monta ApS as independent data controller.
 
-## How long we store personal data
-stroohm.be does not store your personal data for longer than is strictly necessary to achieve the purposes for which your data is collected. We use the following retention periods for the following (categories) of personal data:
+This Privacy Policy applies to: customers (companies and private individuals), contact persons at business partners and prospective customers, website visitors and job applicants.
 
-| (Category) personal data | Legally required retention period |
-|--------------------------|----------------------------------|
-| Personal details         | Legally required retention period |
-| Address                  | Legally required retention period |
+## 2. Which personal data do we process?
 
-## Sharing personal data with third parties
-stroohm.be does not sell your data to third parties and only provides it if this is necessary for the execution of our agreement with you or to comply with a legal obligation. We conclude a processing agreement with companies that process your data on our behalf to ensure the same level of security and confidentiality of your data. stroohm.be remains responsible for these processes.
+### 2.1 Customer and contract data
 
-## Cookies, or similar techniques, that we use
-stroohm.be only uses technical and functional cookies and analytical cookies that do not infringe on your privacy. A cookie is a small text file that is stored on your computer, tablet or smartphone when you first visit this website. The cookies that we use are necessary for the technical operation of the website and your ease of use. They ensure that the website works properly and remember, for example, your preferences. We can also use them to optimize our website. You can opt out of cookies by setting your internet browser so that it no longer stores cookies. In addition, you can also delete all information that was previously stored via the settings of your browser.
+In the context of providing our installation and management services, we process:
 
-## View, modify or delete data
-You have the right to view, correct or delete your personal data. In addition, you have the right to withdraw your consent for the data processing or to object to the processing of your personal data by stroohm.be and you have the right to data portability. This means that you can submit a request to us to send the personal data that we have about you in a computer file to you or another organization named by you.  
-You can send a request for access, correction, deletion, data transfer of your personal data or request for withdrawal of your consent or objection to the processing of your personal data to info@stroohm.be.  
-To ensure that the request for access has been made by you, we ask you to send a copy of your ID with the request. In this copy, black out your passport photo, MRZ (machine readable zone, the strip with numbers at the bottom of the passport), passport number and Citizen Service Number (BSN). This is to protect your privacy. We will respond to your request as soon as possible, but within four weeks.  
-stroohm.be would also like to point out that you have the option to file a complaint with the national supervisory authority, the Dutch Data Protection Authority. This can be done via the following link: [https://autoriteitpersoonsgegevens.nl/nl/contact-met-de-autoriteit-persoonsgegevens/tip-ons](https://autoriteitpersoonsgegevens.nl/nl/contact-met-de-autoriteit-persoonsgegevens/tip-ons)
+- First name and surname of the contact person
+- Job title and company name
+- Email address and telephone number
+- Billing address and delivery address (installation site)
+- VAT number and bank details for invoicing purposes
+- Contractual communications and quotation documents
 
-## How we protect personal data
-stroohm.be takes the protection of your data seriously and takes appropriate measures to prevent misuse, loss, unauthorized access, unwanted disclosure and unauthorized modification. If you have the impression that your data is not properly secured or there are indications of misuse, please contact our customer service or via info@stroohm.be.
+### 2.2 Technical installation data
+
+For the execution and completion of the installation, we process:
+
+- Address details of the installation location (home or office)
+- EAN number of the electricity meter (for dynamic cost optimisation)
+- Technical characteristics of the existing electrical installation
+- Vehicle details of the EV driver (brand, model, connector type) for technical advice
+- Photographs of the installation site (for remote quotation purposes)
+- Inspection reports and commissioning documents
+
+### 2.3 Fleet management data (corporate customers)
+
+For corporate customers using fleet management advice and onboarding services, we process:
+
+- Name and contact details of the fleet manager and/or facility manager
+- List of EV drivers registered in the platform (name, email address, address) for onboarding purposes
+- Linking drivers to organisations for quotation management and installation planning
+
+### 2.4 Website data
+
+- Cookies and similar tracking technologies (see Section 9)
+- IP address, browser type and language
+- Duration of visit and pages visited
+
+> Data relating to platform usage, charging sessions, subscriptions, energy billing, RFID cards, payments and wallet transactions are not processed by STROOHM. Such processing falls exclusively under the responsibility of Monta ApS. Please consult Monta’s privacy policy via https://app.monta.app/privacy-policy.
+
+## 3. Purposes, categories and legal bases
+
+We process your personal data solely for specific, explicit and legitimate purposes. The table below provides an overview of the processing activities carried out by STROOHM:
+
+| Processing purpose | Categories of data | Legal basis (GDPR) | Retention period |
+|---|---|---|---|
+| Execution of installation and maintenance services | Customer and installation data, EAN, address | Performance of a contract – Art. 6(1)(b) | Duration of contract + 3 years |
+| Preparation of quotations and contract management | Contact details, technical data, photographs | Performance of a contract – Art. 6(1)(b) | Duration of contract + 3 years |
+| Customer management and communication | Name, contact details, communication history | Performance of a contract – Art. 6(1)(b) | Duration of contract + 3 years |
+| Fleet onboarding (registering drivers in the platform) | Name, email address, address of EV drivers | Performance of a contract – Art. 6(1)(b) | Until onboarding completion |
+| Invoicing by STROOHM (installation/management) | Invoice data, VAT number, bank details | Performance of a contract – Art. 6(1)(b) | 7 years (Belgian accounting law) |
+| Legal obligations (accounting, audit) | Invoice data, contract data | Legal obligation – Art. 6(1)(c) | 7 years (Belgian accounting law) |
+| Technical support and incident management | Contact details, technical file data | Legitimate interest – Art. 6(1)(f) | 3 years after case closure |
+| Direct marketing (own services) | Name, email address | Consent – Art. 6(1)(a) | Until withdrawal of consent |
+| Website analytics and improvement | Cookie data, anonymised IP address | Consent – Art. 6(1)(a) | See cookie policy |
+| KYC/AML – identity verification and anti-money laundering | Identity data, contract data | Legal obligation – Art. 6(1)(c) | Minimum 7 years |
+
+## 4. Recipients of personal data
+
+STROOHM only shares your personal data with third parties insofar as necessary for the provision of our services or where legally required.
+
+### 4.1 Monta ApS – Independent data controller
+
+In the context of onboarding customers and EV drivers onto the Monta platform, STROOHM shares certain personal data (name, email address, address) with Monta ApS. From that moment onwards, Monta acts as independent data controller for such data insofar as processed in relation to platform usage, subscriptions and energy billing. Monta is not a sub-processor of STROOHM. Monta’s privacy policy can be consulted via:
+https://app.monta.app/privacy-policy
+
+### 4.2 Other recipients
+
+- Subcontractors for installation and maintenance (subject to contractual confidentiality obligations)
+- Accounting and legal advisors (subject to professional secrecy obligations)
+- Public authorities and supervisory bodies (only where legally required)
+- Distribution network operators (for EAN management in relation to dynamic cost optimisation, with your consent)
+
+### 4.3 Transfers outside the EU/EEA
+
+As a general principle, STROOHM does not transfer personal data outside the EU/EEA in relation to its own services. Monta ApS may process data outside the EU/EEA as part of its cloud infrastructure. For such transfers, STROOHM refers to Monta’s privacy policy. More information can be requested via privacy@stroohm.com.
+
+## 5. Retention periods
+
+STROOHM does not retain your personal data longer than necessary for the purposes for which they were collected, taking into account statutory retention obligations.
+
+As a general guideline, we apply the following retention periods:
+
+- Customer and contract data: duration of the contract + 3 years after termination
+- Technical installation files: duration of the contract + 3 years
+- Accounting data (installation/management invoices): 7 years
+- Marketing consent: until withdrawal of consent
+- Recruitment data: 6 months after completion of the procedure (or longer with your consent)
+- KYC/AML data: minimum 7 years
+- Website data (cookies): see our cookie policy
+
+For retention periods applicable to data processed by Monta in relation to platform usage, we refer to Monta’s privacy policy.
+
+After expiry of the retention period, personal data will be securely deleted or anonymised.
+
+## 6. Technical and organisational security measures
+
+STROOHM implements appropriate technical and organisational measures to protect your personal data against loss, unauthorised access, disclosure or destruction.
+
+**Technical measures**
+
+- End-to-end encryption of data in transit (TLS/SSL) and at rest
+- Firewall and network security
+- Role-Based Access Control (RBAC)
+- Multi-factor authentication (MFA) for platform access
+- Regular security patches and updates
+- Logging and monitoring of system access and data traffic
+- Encrypted backups
+
+**Organisational measures**
+
+- Regular employee training regarding data protection
+- Strict access restrictions based on the need-to-know principle
+- Procedures for data breaches and incident management
+- Privacy by design and privacy by default
+- Data processing agreements with all sub-processors
+- Regular security audits
+
+## 7. Your rights as a data subject
+
+In accordance with the GDPR, you have the following rights. You may exercise these rights by submitting a request to privacy@stroohm.com together with proof of identity.
+
+| Right | Legal basis | Explanation |
+|---|---|---|
+| Right of access | Art. 15 GDPR | You may request a copy of the data we process about you. |
+| Right to rectification | Art. 16 GDPR | You may request correction of inaccurate or incomplete data. |
+| Right to erasure | Art. 17 GDPR | You may request deletion of your personal data. |
+| Right to restriction | Art. 18 GDPR | You may request restriction of processing in certain cases. |
+| Right to data portability | Art. 20 GDPR | You may receive your data in a structured format or transfer them. |
+| Right to object | Art. 21 GDPR | You may object to processing based on legitimate interests. |
+| Right to withdraw consent | Art. 7 GDPR | You may withdraw previously given consent at any time. |
+
+We will process your request within 30 days. In the case of complex or extensive requests, this period may be extended by a maximum of 2 additional months, subject to notification.
+
+If you are not satisfied with the manner in which STROOHM processes your personal data, you have the right to lodge a complaint with the competent supervisory authority:
+
+**Belgian Data Protection Authority (DPA)**
+
+- Address: Rue de la Presse 35, 1000 Brussels, Belgium
+- Website: www.dataprotectionauthority.be
+- Email: contact@apd-gba.be
+
+## 8. Automated decision-making and profiling
+
+8.1 STROOHM does not engage in fully automated decision-making producing legal effects concerning data subjects within the meaning of Art. 22 GDPR.
+
+8.2 We may use anonymised or aggregated data for analytical purposes (e.g. platform improvement, optimisation of charging infrastructure). Such analyses do not affect individual data subjects.
+
+## 9. Cookies and tracking technologies
+
+9.1 STROOHM and Monta use cookies and similar technologies on the Platform and website. Upon your first visit, you will be asked to consent to the use of non-essential cookies.
+
+9.2 The following categories of cookies are used:
+
+- Strictly necessary cookies: essential for operation of the Platform (login, security). These cannot be disabled.
+- Analytical cookies: used to measure and improve Platform usage (e.g. anonymised statistics).
+- Functional cookies: used to remember your preferences (language, settings).
+
+9.3 You may modify your cookie preferences at any time through the cookie settings within the Platform or through your browser settings.
+
+## 10. Special categories of personal data
+
+STROOHM does not process special categories of personal data (such as health data, biometric data, political opinions, etc.) in relation to charging services. We expressly request that you do not share such sensitive information through the Platform or in communications with STROOHM.
+
+## 11. Minors
+
+The Platform is not intended for persons under the age of 16. STROOHM does not knowingly collect personal data from minors. If you become aware that a minor has provided data without consent, please contact us via privacy@stroohm.com.
+
+## 12. Applicable law
+
+This Privacy Policy has been drafted in accordance with:
+
+- Regulation (EU) 2016/679 of 27 April 2016 (GDPR)
+- The Belgian Act of 30 July 2018 on the protection of natural persons with regard to the processing of personal data
+- The Belgian Act of 13 June 2005 on electronic communications (cookies and electronic communications)
+
+## 13. Amendments to this Privacy Policy
+
+STROOHM reserves the right to amend this Privacy Policy, for example in response to new legal obligations, technological developments or changes to our services.
+
+Material changes will be communicated at least 30 days before entering into force via email or a notification on the Platform. The most recent version will always be available on our website.
+
+## 14. Contact details
+
+For questions regarding this Privacy Policy, the exercise of your rights as a data subject, or complaints regarding the processing of your personal data, you may contact:
+
+- **Data Controller:** STROOHM BV
+- **Company Registration No.:** 0716.755.863
+- **Address:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Privacy Email:** privacy@stroohm.com
+- **General Email:** info@stroohm.com
+- **Website:** www.stroohm.com
+- **DPA Complaints:** www.gegevensbeschermingsautoriteit.be
+
+_This Privacy Policy was last updated on 18 May 2026._
+
+---
+
+# STROOHM Déclaration de confidentialité (Français)
+
+- **Date :** Mai 2026
+- **Responsable du traitement :** STROOHM BV
+- **Numéro BCE :** 0716.755.863
+- **Siège social :** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Contact vie privée :** privacy@stroohm.com
+- **Opérateur de la plateforme (responsable indépendant) :** Monta ApS – https://app.monta.app/privacy-policy
+
+> **Champ d’application :** la présente Déclaration de confidentialité s’applique aux données à caractère personnel traitées par STROOHM BV dans le cadre de ses propres services (installation, maintenance, gestion des clients). Pour le traitement des données à caractère personnel par Monta ApS dans le cadre de la plateforme de recharge, des abonnements et de la facturation énergétique, Monta agit en tant que responsable du traitement indépendant. Veuillez consulter la politique de confidentialité de Monta via https://app.monta.app/privacy-policy
+
+## 1. Introduction et identité du responsable du traitement
+
+STROOHM BV (ci-après « STROOHM », « nous », « notre ») attache une grande importance à la protection de vos données à caractère personnel et les traite avec le soin nécessaire, conformément au Règlement général sur la protection des données (RGPD – Règlement (UE) 2016/679) et à la législation belge applicable en matière de protection des données.
+
+STROOHM BV agit en tant que responsable du traitement pour les données à caractère personnel collectées dans le cadre de ses propres services, notamment :
+
+- L’installation et la maintenance d’infrastructures de recharge
+- La gestion commerciale et administrative des clients
+- La facturation des services d’installation et de gestion fournis par STROOHM
+- La communication avec les clients, partenaires et visiteurs du site web
+
+STROOHM ne traite pas les données à caractère personnel des utilisateurs finaux (conducteurs de VE) dans le cadre de l’utilisation de la plateforme, des sessions de recharge, des abonnements ou de la facturation énergétique. Ce traitement relève exclusivement de la responsabilité de Monta ApS en tant que responsable du traitement indépendant.
+
+La présente Déclaration de confidentialité s’applique aux : clients (entreprises et particuliers), personnes de contact auprès de partenaires commerciaux et prospects, visiteurs du site web et candidats.
+
+## 2. Quelles données à caractère personnel traitons-nous ?
+
+### 2.1 Données clients et contractuelles
+
+Dans le cadre de l’exécution de nos services d’installation et de gestion, nous traitons :
+
+- Nom et prénom de la personne de contact
+- Fonction et nom de l’entreprise
+- Adresse e-mail et numéro de téléphone
+- Adresse de facturation et adresse de livraison (site d’installation)
+- Numéro de TVA et coordonnées bancaires à des fins de facturation
+- Communications contractuelles et documents d’offre
+
+### 2.2 Données techniques d’installation
+
+Pour l’exécution et la réception de l’installation, nous traitons :
+
+- Les coordonnées du lieu d’installation (domicile ou bureau)
+- Le numéro EAN du compteur électrique (pour l’optimisation dynamique des coûts)
+- Les caractéristiques techniques de l’installation électrique existante
+- Les données du véhicule du conducteur de VE (marque, modèle, type de connecteur) à des fins de conseil technique
+- Des photos du site d’installation (pour l’établissement d’offres à distance)
+- Les rapports de contrôle et documents de mise en service
+
+### 2.3 Données de fleet management (clients professionnels)
+
+Pour les clients professionnels utilisant des services de conseil et d’onboarding fleet management, nous traitons :
+
+- Le nom et les coordonnées du fleet manager et/ou facility manager
+- La liste des conducteurs de VE enregistrés sur la plateforme (nom, e-mail, adresse) à des fins d’onboarding
+- Le lien entre le conducteur et l’organisation pour la gestion des offres et la planification des installations
+
+### 2.4 Données relatives au site web
+
+- Cookies et technologies de suivi similaires (voir Section 9)
+- Adresse IP, type de navigateur et langue
+- Durée de la visite et pages consultées
+
+> Les données relatives à l’utilisation de la plateforme, aux sessions de recharge, aux abonnements, à la facturation énergétique, aux cartes RFID, aux paiements et aux transactions wallet ne sont pas traitées par STROOHM. Ce traitement relève exclusivement de la responsabilité de Monta ApS. Veuillez consulter la politique de confidentialité de Monta via https://app.monta.app/privacy-policy.
+
+## 3. Finalités, catégories et bases juridiques
+
+Nous traitons vos données à caractère personnel uniquement pour des finalités déterminées, explicites et légitimes. Le tableau ci-dessous donne un aperçu des traitements effectués par STROOHM :
+
+| Finalité du traitement | Catégories de données | Base juridique (RGPD) | Durée de conservation |
+|---|---|---|---|
+| Exécution des services d’installation et de maintenance | Données clients et d’installation, EAN, adresse | Exécution d’un contrat – Art. 6(1)(b) | Durée du contrat + 3 ans |
+| Établissement des offres et gestion des contrats | Coordonnées, données techniques, photos | Exécution d’un contrat – Art. 6(1)(b) | Durée du contrat + 3 ans |
+| Gestion des clients et communication | Nom, coordonnées, historique des communications | Exécution d’un contrat – Art. 6(1)(b) | Durée du contrat + 3 ans |
+| Fleet onboarding (enregistrement des conducteurs sur la plateforme) | Nom, e-mail, adresse des conducteurs de VE | Exécution d’un contrat – Art. 6(1)(b) | Jusqu’à la finalisation de l’onboarding |
+| Facturation par STROOHM (installation/gestion) | Données de facturation, numéro de TVA, coordonnées bancaires | Exécution d’un contrat – Art. 6(1)(b) | 7 ans (législation comptable belge) |
+| Obligations légales (comptabilité, audit) | Données de facturation, données contractuelles | Obligation légale – Art. 6(1)(c) | 7 ans (législation comptable belge) |
+| Support technique et gestion des incidents | Coordonnées, données des dossiers techniques | Intérêt légitime – Art. 6(1)(f) | 3 ans après clôture du dossier |
+| Marketing direct (services propres) | Nom, e-mail | Consentement – Art. 6(1)(a) | Jusqu’au retrait du consentement |
+| Analyse et amélioration du site web | Données cookies, adresse IP anonymisée | Consentement – Art. 6(1)(a) | Voir politique cookies |
+| KYC/AML – vérification d’identité et lutte contre le blanchiment | Données d’identité, données contractuelles | Obligation légale – Art. 6(1)(c) | 7 ans minimum (législation anti-blanchiment) |
+
+## 4. Destinataires des données à caractère personnel
+
+STROOHM ne partage vos données à caractère personnel avec des tiers que dans la mesure nécessaire à l’exécution de ses services ou lorsqu’une obligation légale l’impose.
+
+### 4.1 Monta ApS – Responsable du traitement indépendant
+
+Dans le cadre de l’onboarding des clients et conducteurs de VE sur la plateforme Monta, STROOHM partage certaines données à caractère personnel (nom, e-mail, adresse) avec Monta ApS. À partir de ce moment, Monta agit en tant que responsable du traitement indépendant pour ces données dans le cadre de l’utilisation de la plateforme, des abonnements et de la facturation énergétique. Monta n’est pas un sous-traitant de STROOHM.
+
+La politique de confidentialité de Monta est consultable via :
+https://app.monta.app/privacy-policy
+
+### 4.2 Autres destinataires
+
+- Sous-traitants chargés de l’installation et de la maintenance (soumis à une obligation contractuelle de confidentialité)
+- Conseillers comptables et juridiques (soumis au secret professionnel)
+- Autorités publiques et organismes de contrôle (uniquement en cas d’obligation légale)
+- Gestionnaires de réseau de distribution (pour la gestion des EAN dans le cadre de l’optimisation dynamique des coûts, avec votre consentement)
+
+### 4.3 Transferts en dehors de l’UE/EEE
+
+En principe, STROOHM ne transfère pas de données à caractère personnel en dehors de l’UE/EEE dans le cadre de ses propres services. Monta ApS peut toutefois traiter des données en dehors de l’UE/EEE dans le cadre de son infrastructure cloud. Pour ces transferts, STROOHM renvoie à la politique de confidentialité de Monta. Vous pouvez obtenir davantage d’informations via privacy@stroohm.com.
+
+## 5. Durées de conservation
+
+STROOHM ne conserve pas vos données à caractère personnel plus longtemps que nécessaire au regard des finalités pour lesquelles elles ont été collectées, en tenant compte des obligations légales de conservation.
+
+À titre indicatif, nous appliquons les durées suivantes :
+
+- Données clients et contractuelles : durée du contrat + 3 ans après sa fin
+- Dossiers techniques d’installation : durée du contrat + 3 ans
+- Données comptables (factures installation/gestion) : 7 ans
+- Consentement marketing : jusqu’au retrait du consentement
+- Données de candidature : 6 mois après la fin de la procédure (ou plus longtemps avec votre consentement)
+- Données KYC/AML : minimum 7 ans
+- Données du site web (cookies) : voir notre politique cookies
+
+Pour les durées de conservation des données traitées par Monta dans le cadre de l’utilisation de la plateforme, veuillez consulter la politique de confidentialité de Monta.
+
+À l’expiration des délais de conservation, les données à caractère personnel sont supprimées ou anonymisées de manière sécurisée.
+
+## 6. Mesures techniques et organisationnelles de sécurité
+
+STROOHM met en œuvre des mesures techniques et organisationnelles appropriées afin de protéger vos données à caractère personnel contre la perte, l’accès non autorisé, la divulgation ou la destruction.
+
+**Mesures techniques**
+
+- Chiffrement de bout en bout des données en transit (TLS/SSL) et au repos
+- Pare-feu et sécurité réseau
+- Contrôle d’accès basé sur les rôles (Role-Based Access Control)
+- Authentification multifacteur (MFA) pour l’accès à la plateforme
+- Correctifs et mises à jour de sécurité réguliers
+- Journalisation et surveillance des accès systèmes et des flux de données
+- Sauvegardes chiffrées
+
+**Mesures organisationnelles**
+
+- Formation régulière des collaborateurs en matière de protection des données
+- Restriction stricte des accès aux données selon le principe du « need-to-know »
+- Procédures relatives aux violations de données et à la gestion des incidents
+- Privacy by design et privacy by default
+- Contrats de sous-traitance avec tous les sous-traitants
+- Audits de sécurité réguliers
+
+## 7. Vos droits en tant que personne concernée
+
+Conformément au RGPD, vous disposez des droits suivants. Vous pouvez les exercer en adressant une demande à privacy@stroohm.com accompagnée d’une preuve d’identité.
+
+| Droit | Base juridique | Explication |
+|---|---|---|
+| Droit d’accès | Art. 15 RGPD | Vous pouvez demander une copie des données que nous traitons vous concernant. |
+| Droit de rectification | Art. 16 RGPD | Vous pouvez demander la correction de données inexactes ou incomplètes. |
+| Droit à l’effacement | Art. 17 RGPD | Vous pouvez demander la suppression de vos données à caractère personnel. |
+| Droit à la limitation | Art. 18 RGPD | Vous pouvez demander la limitation du traitement dans certains cas. |
+| Droit à la portabilité | Art. 20 RGPD | Vous pouvez recevoir vos données dans un format structuré ou les transférer. |
+| Droit d’opposition | Art. 21 RGPD | Vous pouvez vous opposer à un traitement fondé sur l’intérêt légitime. |
+| Droit de retrait du consentement | Art. 7 RGPD | Vous pouvez retirer votre consentement à tout moment. |
+
+Nous traiterons votre demande dans un délai de 30 jours. En cas de demande complexe ou volumineuse, ce délai peut être prolongé de maximum 2 mois supplémentaires, moyennant notification.
+
+Si vous n’êtes pas satisfait de la manière dont STROOHM traite vos données à caractère personnel, vous avez le droit d’introduire une plainte auprès de l’autorité de contrôle compétente :
+
+**Autorité de protection des données (APD)**
+
+- Adresse : Rue de la Presse 35, 1000 Bruxelles
+- Site web : www.autoriteprotectiondonnees.be
+- E-mail : contact@apd-gba.be
+
+## 8. Prise de décision automatisée et profilage
+
+8.1 STROOHM n’a pas recours à une prise de décision entièrement automatisée produisant des effets juridiques concernant les personnes concernées au sens de l’Art. 22 RGPD.
+
+8.2 Nous pouvons utiliser des données anonymisées ou agrégées à des fins analytiques (par ex. amélioration de la plateforme, optimisation des infrastructures de recharge). Ces analyses n’ont aucun impact sur les personnes concernées individuellement.
+
+## 9. Cookies et technologies de suivi
+
+9.1 STROOHM et Monta utilisent des cookies et technologies similaires sur la plateforme et le site web. Lors de votre première visite, votre consentement sera demandé pour l’utilisation des cookies non essentiels.
+
+9.2 Les catégories de cookies suivantes sont utilisées :
+
+- Cookies strictement nécessaires : essentiels au fonctionnement de la plateforme (connexion, sécurité). Ils ne peuvent pas être désactivés.
+- Cookies analytiques : utilisés pour mesurer et améliorer l’utilisation de la plateforme (par ex. statistiques anonymisées).
+- Cookies fonctionnels : utilisés pour mémoriser vos préférences (langue, paramètres).
+
+9.3 Vous pouvez modifier vos préférences en matière de cookies à tout moment via les paramètres cookies de la plateforme ou via les paramètres de votre navigateur.
+
+## 10. Catégories particulières de données à caractère personnel
+
+STROOHM ne traite pas de catégories particulières de données à caractère personnel (telles que données de santé, biométriques, opinions politiques, etc.) dans le cadre des services de recharge. Nous vous demandons expressément de ne pas partager ce type d’informations sensibles via la plateforme ou dans vos communications avec STROOHM.
+
+## 11. Mineurs
+
+La plateforme n’est pas destinée aux personnes de moins de 16 ans. STROOHM ne collecte pas sciemment de données à caractère personnel de mineurs. Si vous constatez qu’un mineur a fourni des données sans autorisation, veuillez nous contacter via privacy@stroohm.com.
+
+## 12. Droit applicable
+
+La présente Déclaration de confidentialité a été rédigée conformément :
+
+- Au Règlement (UE) 2016/679 du 27 avril 2016 (RGPD)
+- À la loi belge du 30 juillet 2018 relative à la protection des personnes physiques à l’égard des traitements de données à caractère personnel
+- À la loi belge du 13 juin 2005 relative aux communications électroniques (cookies et communications électroniques)
+
+## 13. Modifications de la présente Déclaration de confidentialité
+
+STROOHM se réserve le droit de modifier la présente Déclaration de confidentialité, notamment en raison de nouvelles obligations légales, d’évolutions technologiques ou de modifications de ses services.
+
+Les modifications substantielles seront communiquées au moins 30 jours avant leur entrée en vigueur, par e-mail ou via une notification sur la plateforme. La version la plus récente sera toujours disponible sur notre site web.
+
+## 14. Coordonnées de contact
+
+Pour toute question concernant la présente Déclaration de confidentialité, l’exercice de vos droits en tant que personne concernée ou toute plainte relative au traitement de vos données à caractère personnel, vous pouvez contacter :
+
+- **Responsable du traitement :** STROOHM BV
+- **Numéro BCE :** 0716.755.863
+- **Adresse :** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **E-mail vie privée :** privacy@stroohm.com
+- **E-mail général :** info@stroohm.com
+- **Site web :** www.stroohm.com
+- **Plaintes APD :** www.gegevensbeschermingsautoriteit.be
+
+_La présente Déclaration de confidentialité a été mise à jour pour la dernière fois le 18 mai 2026._
+
+---
+
+# STROOHM Privacyverklaring (Nederlands)
+
+- **Datum:** Mei 2026
+- **Verwerkingsverantwoordelijke:** STROOHM BV
+- **KBO-nummer:** 0716.755.863
+- **Maatschappelijke zetel:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Privacy contact:** privacy@stroohm.com
+- **Platformoperator (zelfstandig verantwoordelijke):** Monta ApS – https://app.monta.app/privacy-policy
+
+> **Toepassingsgebied:** deze privacyverklaring heeft betrekking op de persoonsgegevens die STROOHM BV verwerkt in het kader van zijn eigen diensten (installatie, onderhoud, klantenbeheer). Voor de verwerking van persoonsgegevens door Monta ApS in het kader van het laadplatform, abonnementen en energiefacturatie is Monta de zelfstandige verwerkingsverantwoordelijke. Raadpleeg hiervoor het privacybeleid van Monta via https://app.monta.app/privacy-policy.
+
+## 1. Inleiding en identiteit verwerkingsverantwoordelijke
+
+STROOHM BV (hierna "STROOHM", "wij", "ons") hecht veel belang aan de bescherming van uw persoonsgegevens en verwerkt deze met de nodige zorgvuldigheid, in overeenstemming met de Europese Algemene Verordening Gegevensbescherming (AVG/GDPR – Verordening (EU) 2016/679) en de Belgische wetgeving inzake gegevensbescherming.
+
+STROOHM BV treedt op als verwerkingsverantwoordelijke voor de verwerking van persoonsgegevens die worden verzameld in het kader van zijn eigen diensten:
+
+- De installatie en het onderhoud van laadinfrastructuur
+- Het commercieel en administratief klantenbeheer
+- De facturatie voor installatie- en beheerdiensten door STROOHM
+- De communicatie met klanten, partners en websitebezoekers
+
+STROOHM verwerkt geen persoonsgegevens van eindgebruikers (EV-bestuurders) in het kader van het platformgebruik, de laadsessies, de abonnementen of de energiefacturatie. Die verwerking valt uitsluitend onder de verantwoordelijkheid van Monta ApS als zelfstandige verwerkingsverantwoordelijke.
+
+Deze Privacyverklaring is van toepassing op: klanten (bedrijven en particulieren), contactpersonen bij zakenpartners en potentiële klanten, websitebezoekers en sollicitanten.
+
+## 2. Welke persoonsgegevens verwerken wij?
+
+### 2.1 Klant- en contractgegevens
+
+In het kader van de uitvoering van onze installatie- en beheerdiensten verwerken wij:
+
+- Naam en voornaam van de contactpersoon
+- Functietitel en naam van de onderneming
+- E-mailadres en telefoonnummer
+- Facturatieadres en leveringsadres (installatiepunt)
+- BTW-nummer en bankgegevens voor facturatie
+- Contractuele communicatie en offertedocumenten
+
+### 2.2 Technische installatiegegevens
+
+Voor de uitvoering en oplevering van de installatie verwerken wij:
+
+- Adresgegevens van de installatielocatie (thuis of kantoor)
+- EAN-nummer van de elektriciteitsmeter (voor dynamische kostoptimalisatie)
+- Technische kenmerken van de bestaande elektrische installatie
+- Voertuiggegevens van de EV-bestuurder (merk, model, connectortype) – voor technisch advies
+- Foto's van de installatielocatie (voor offerteopmaak op afstand)
+- Keuringsverslagen en opleverdocumenten
+
+### 2.3 Fleet management gegevens (bedrijfsklanten)
+
+Voor bedrijfsklanten die gebruik maken van fleet management advies en onboarding verwerken wij:
+
+- Naam en contactgegevens van de fleet manager en/of facility manager
+- Lijst van EV-bestuurders die in het platform worden aangemeld (naam, e-mail, adres) – ten behoeve van onboarding
+- Koppeling van bestuurder aan organisatie voor offertebeheer en installatieplanning
+
+### 2.4 Websitegegevens
+
+- Cookies en vergelijkbare trackingtechnologieën (zie Sectie 9)
+- IP-adres, browsertype en taal
+- Duur van het bezoek en bezochte pagina's
+
+> Gegevens m.b.t. het platformgebruik, laadsessies, abonnementen, energiefacturatie, RFID-kaarten, betalingen en wallet-transacties worden niet door STROOHM verwerkt. Die verwerking valt uitsluitend onder de verantwoordelijkheid van Monta ApS. Raadpleeg het privacybeleid van Monta via https://app.monta.app/privacy-policy.
+
+## 3. Doeleinden, categorieën en rechtsgronden
+
+Wij verwerken uw persoonsgegevens uitsluitend voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden. Onderstaande tabel geeft een overzicht van de verwerkingen door STROOHM:
+
+| Verwerkingsdoel | Categorieën van gegevens | Rechtsgrond (AVG) | Bewaartermijn |
+|---|---|---|---|
+| Uitvoering installatie- en onderhoudsopdracht | Klant- en installatiegegevens, EAN, adres | Uitvoering overeenkomst – Art. 6(1)(b) | Duur overeenkomst + 3 jaar |
+| Offerteopmaak en contractbeheer | Contactgegevens, technische gegevens, foto's | Uitvoering overeenkomst – Art. 6(1)(b) | Duur overeenkomst + 3 jaar |
+| Klantenbeheer en communicatie | Naam, contactgegevens, communicatiehistoriek | Uitvoering overeenkomst – Art. 6(1)(b) | Duur overeenkomst + 3 jaar |
+| Fleet onboarding (aanmelden bestuurders in platform) | Naam, e-mail, adres van EV-bestuurders | Uitvoering overeenkomst – Art. 6(1)(b) | Tot voltooiing onboarding |
+| Facturatie door STROOHM (installatie/beheer) | Factuurgegevens, BTW-nummer, bankgegevens | Uitvoering overeenkomst – Art. 6(1)(b) | 7 jaar (Belgische boekhoudwet) |
+| Wettelijke verplichtingen (boekhouding, audit) | Factuurgegevens, contractdata | Wettelijke verplichting – Art. 6(1)(c) | 7 jaar (Belgische boekhoudwet) |
+| Technische ondersteuning en incidentbeheer | Contactgegevens, technische dossierdata | Gerechtvaardigd belang – Art. 6(1)(f) | 3 jaar na afsluiting dossier |
+| Direct marketing (eigen diensten) | Naam, e-mail | Toestemming – Art. 6(1)(a) | Tot herroeping toestemming |
+| Websiteanalyse en verbetering | Cookiedata, IP-adres (geanonimiseerd) | Toestemming – Art. 6(1)(a) | Zie cookiebeleid |
+| KYC/AML – identiteitsverificatie en antiwitwas | Identiteitsgegevens, contractdata | Wettelijke verplichting – Art. 6(1)(c) | Min. 7 jaar (antiwitwaswetgeving) |
+
+## 4. Ontvangers van persoonsgegevens
+
+STROOHM deelt uw persoonsgegevens uitsluitend met derden voor zover dit noodzakelijk is voor de uitvoering van onze diensten of wettelijk vereist is.
+
+### 4.1 Monta ApS – Zelfstandige verwerkingsverantwoordelijke
+
+In het kader van de onboarding van klanten en EV-bestuurders op het Monta-platform deelt STROOHM bepaalde persoonsgegevens (naam, e-mail, adres) met Monta ApS. Vanaf dat moment is Monta de zelfstandige verwerkingsverantwoordelijke voor die gegevens, voor zover verwerkt in het kader van het platformgebruik, de abonnementen en de energiefacturatie. Monta is geen subverwerker van STROOHM.
+
+Het privacybeleid van Monta is raadpleegbaar via:
+https://app.monta.app/privacy-policy
+
+### 4.2 Andere ontvangers
+
+- Onderaannemers voor installatie en onderhoud (onder contractuele geheimhoudingsplicht)
+- Boekhoudkundige en juridische adviseurs (onder professionele geheimhoudingsplicht)
+- Overheidsinstanties en toezichthouders (uitsluitend bij wettelijke verplichting)
+- Distributienetbeheerders (voor EAN-beheer bij dynamische kostoptimalisatie, met uw toestemming)
+
+### 4.3 Doorgifte buiten de EU/EER
+
+STROOHM geeft in beginsel geen persoonsgegevens door buiten de EU/EER in het kader van zijn eigen diensten. Monta ApS kan in het kader van haar cloudinfrastructuur data verwerken buiten de EU/EER. Voor die doorgiftes verwijst STROOHM naar het privacybeleid van Monta. U kunt hierover meer informatie opvragen via privacy@stroohm.com.
+
+## 5. Bewaartermijnen
+
+STROOHM bewaart uw persoonsgegevens niet langer dan noodzakelijk voor het doel waarvoor zij werden verzameld, rekening houdend met de wettelijke bewaarverplichtingen.
+
+Als algemene richtlijn hanteren wij:
+
+- Klant- en contractgegevens: duur van de overeenkomst + 3 jaar na beëindiging
+- Technische installatiedossiers: duur van de overeenkomst + 3 jaar
+- Boekhoudkundige gegevens (facturen voor installatie/beheer): 7 jaar (Belgische boekhoudwetgeving)
+- Marketingtoestemming: tot herroeping van de toestemming
+- Sollicitatiegegevens: 6 maanden na afronding procedure (of langer met uw toestemming)
+- KYC/AML-gegevens (identiteitsverificatie, antiwitwas): minimum 7 jaar (wettelijke verplichting – antiwitwaswetgeving)
+- Websitegegevens (cookies): zie ons cookiebeleid
+
+Voor bewaartermijnen van gegevens die Monta verwerkt in het kader van het platformgebruik, verwijzen wij naar het privacybeleid van Monta.
+
+Na het verstrijken van de bewaartermijn worden persoonsgegevens veilig gewist of geanonimiseerd.
+
+## 6. Technische en organisatorische beveiligingsmaatregelen
+
+STROOHM neemt passende technische en organisatorische maatregelen om uw persoonsgegevens te beschermen tegen verlies, ongeoorloofde toegang, openbaarmaking of vernietiging:
+
+**Technische maatregelen**
+
+- End-to-end versleuteling van gegevens in transit (TLS/SSL) en in rust
+- Firewall- en netwerkbeveiliging
+- Toegangscontrole op basis van rollen (Role-Based Access Control)
+- Multi-factor authenticatie (MFA) voor platformtoegang
+- Regelmatige beveiligingspatches en -updates
+- Logging en monitoring van systeemtoegang en dataverkeer
+- Versleutelde back-ups
+
+**Organisatorische maatregelen**
+
+- Regelmatige opleiding van medewerkers inzake gegevensbescherming
+- Strikte toegangsbeperking tot persoonsgegevens (need-to-know-principe)
+- Procedures voor datalekken en incidentbeheer
+- Privacy by design & privacy by default als leidend principe
+- Verwerkersovereenkomsten met alle subverwerkers
+- Regelmatige beveiligingsaudits
+
+## 7. Uw rechten als betrokkene
+
+Conform de AVG heeft u als betrokkene de volgende rechten. U kunt deze uitoefenen door een verzoek te richten aan privacy@stroohm.com, samen met een bewijs van uw identiteit.
+
+| Recht | Rechtsgrond | Toelichting |
+|---|---|---|
+| Recht op inzage | Art. 15 AVG | U kunt een kopie opvragen van de gegevens die wij over u verwerken. |
+| Recht op rectificatie | Art. 16 AVG | U kunt onjuiste of onvolledige gegevens laten corrigeren. |
+| Recht op vergetelheid | Art. 17 AVG | U kunt verzoeken om verwijdering van uw persoonsgegevens. |
+| Recht op beperking | Art. 18 AVG | U kunt de verwerking laten beperken in bepaalde gevallen. |
+| Recht op overdraagbaarheid | Art. 20 AVG | U kunt uw gegevens in een leesbaar formaat ontvangen of overdragen. |
+| Recht van bezwaar | Art. 21 AVG | U kunt bezwaar maken tegen verwerking op basis van gerechtvaardigd belang. |
+| Recht intrekking toestemming | Art. 7 AVG | U kunt eerder gegeven toestemming te allen tijde intrekken. |
+
+Wij behandelen uw verzoek binnen 30 dagen. In geval van complexe of omvangrijke verzoeken kan deze termijn worden verlengd met maximaal 2 maanden, mits kennisgeving.
+
+Indien u niet tevreden bent met de wijze waarop STROOHM uw persoonsgegevens verwerkt, heeft u het recht een klacht in te dienen bij de bevoegde toezichthoudende autoriteit:
+
+**Gegevensbeschermingsautoriteit (GBA)**
+
+- Adres: Drukpersstraat 35, 1000 Brussel
+- Website: www.gegevensbeschermingsautoriteit.be
+- E-mail: contact@apd-gba.be
+
+## 8. Geautomatiseerde besluitvorming en profilering
+
+8.1 STROOHM maakt geen gebruik van volledig geautomatiseerde besluitvorming die rechtsgevolgen heeft voor betrokkenen, in de zin van Art. 22 AVG.
+
+8.2 Wij kunnen geanonimiseerde of geaggregeerde gegevens gebruiken voor analytische doeleinden (bijv. verbetering van het Platform, optimalisatie van laadinfrastructuur). Deze analyses hebben geen impact op individuele betrokkenen.
+
+## 9. Cookies en trackingtechnologieën
+
+9.1 STROOHM en Monta maken gebruik van cookies en vergelijkbare technologieën op het Platform en de website. Bij uw eerste bezoek wordt u om toestemming gevraagd voor het gebruik van niet-essentiële cookies.
+
+9.2 De volgende categorieën van cookies worden gebruikt:
+
+- Strikt noodzakelijke cookies: essentieel voor de werking van het Platform (login, beveiliging). Deze kunnen niet worden uitgeschakeld.
+- Analytische cookies: om het gebruik van het Platform te meten en te verbeteren (bijv. via geanonimiseerde statistieken).
+- Functionele cookies: om uw voorkeuren te onthouden (taal, instellingen).
+
+9.3 U kunt uw cookievoorkeuren op elk moment aanpassen via de cookie-instellingen in het Platform of via de browserinstellingen.
+
+## 10. Bijzondere categorieën van persoonsgegevens
+
+STROOHM verwerkt geen bijzondere categorieën van persoonsgegevens (zoals gezondheidsgegevens, biometrische gegevens, politieke opvattingen, etc.) in het kader van de laaddiensten. Wij verzoeken u uitdrukkelijk om geen dergelijke gevoelige informatie te delen via het Platform of in communicatie met STROOHM.
+
+## 11. Minderjarigen
+
+Het Platform is niet bestemd voor personen jonger dan 16 jaar. STROOHM verzamelt niet bewust persoonsgegevens van minderjarigen. Indien u vaststelt dat een minderjarige zonder toestemming gegevens heeft verstrekt, verzoeken wij u contact op te nemen via privacy@stroohm.com.
+
+## 12. Toepasselijk recht
+
+Deze Privacyverklaring is opgesteld in overeenstemming met:
+
+- Verordening (EU) 2016/679 van 27 april 2016 (AVG/GDPR)
+- De wet van 30 juli 2018 betreffende de bescherming van natuurlijke personen met betrekking tot de verwerking van persoonsgegevens (Belgische implementatiewet AVG)
+- De wet van 13 juni 2005 betreffende de elektronische communicatie (voor cookies en elektronische communicatie)
+
+## 13. Wijzigingen aan deze Privacyverklaring
+
+STROOHM behoudt zich het recht voor deze Privacyverklaring te wijzigen, bijvoorbeeld naar aanleiding van nieuwe wettelijke verplichtingen, technologische ontwikkelingen of wijzigingen in onze dienstverlening.
+
+Materiële wijzigingen worden ten minste 30 dagen vóór inwerkingtreding meegedeeld via e-mail of via een kennisgeving in het Platform. De meest actuele versie is steeds raadpleegbaar via onze website.
+
+## 14. Contactgegevens
+
+Voor vragen over deze Privacyverklaring, het uitoefenen van uw rechten als betrokkene, of klachten over de verwerking van uw persoonsgegevens, kunt u contact opnemen met:
+
+- **Verwerkingsverantwoordelijke:** STROOHM BV
+- **KBO-nummer:** 0716.755.863
+- **Adres:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **E-mail privacy:** privacy@stroohm.com
+- **E-mail algemeen:** info@stroohm.com
+- **Website:** www.stroohm.com
+- **Klachten GBA:** www.gegevensbeschermingsautoriteit.be
+
+_Deze Privacyverklaring is voor het laatst bijgewerkt op 18 mei 2026._

--- a/en-stroohm-terms-of-use.md
+++ b/en-stroohm-terms-of-use.md
@@ -1,146 +1,506 @@
-# STROOHM TERMS & CONDITIONS
+# Table of Contents
 
-**stroohm.be**, located at Interescautlaan 100 B2.12 Schelle 2627, is responsible for the processing of personal data as shown in this privacy statement.
+- [STROOHM General Terms and Conditions (English)](#stroohm-general-terms-and-conditions-english)
+- [STROOHM Conditions Générales (Français)](#stroohm-conditions-gnrales-franais)
+- [STROOHM Algemene Voorwaarden (Nederlands)](#stroohm-algemene-voorwaarden-nederlands)
 
-**Contact details:**  
-[stroohm.be](https://stroohm.be/)  
-Interescautlaan 100 B2.12 Schelle 2627  
-info@stroohm.be  
+---
 
-## Article 1: Scope of application
+# STROOHM General Terms and Conditions (English)
 
-1.1. These general terms and conditions apply to all quotations, orders, advice, projects, agreements, with and by STROOHM BV, with registered office at Interescautlaan 100 B2.12 Schelle 2627, KBO no. 0716.755.863 (hereinafter “Stroohm”). They form an integral part of every agreement concluded with the Customer. They are deemed to be known and accepted by the Customer. The Customer’s general terms and conditions are expressly excluded, even if they are communicated after communication of these conditions. Stroohm’s special conditions always take precedence over its general conditions, insofar as they deviate from them.
+**General Terms and Conditions Installation & Management**
 
-## Article 2: quotations – prices
+- **Date:** May 2026
+- **Responsible Party:** STROOHM BV
+- **Company registration no.:** 0716.755.863
+- **Registered Office:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Contact:** info@stroohm.com
 
-2.1. All our price quotations, the prices and/or other information stated in price lists, catalogues, correspondence and other documents are drawn up in good faith but approximately on the basis of current prices. Our prices and offers are without obligation and without any obligation towards the Customer. The quotation only binds Stroohm if legally signed by the Customer and by a director of Stroohm. All prices are exclusive of VAT, ex works, unless stated otherwise. Stroohm’s quotations are valid for a maximum of thirty (30) working days. All statutory charges and taxes are borne by the Customer.
+> **Scope:** these general terms and conditions govern exclusively the services that STROOHM BV provides directly to the Client: the installation of charging infrastructure, maintenance, management and related services. The use of the digital charging platform (Monta or other supplier) and the invoicing of subscriptions and energy consumption are subject to the terms and conditions of Monta ApS (or other supplier), which directly connect the Client and end users with Monta (or other supplier).
 
-2.2. In accordance with the legal provisions, the Client, who cannot be considered a company, has the right to terminate this agreement within 14 calendar days from the day following the signing of the current agreement, without giving reasons and without compensation, insofar as this agreement was signed outside the offices of Stroohm. This termination must be done by the client by registered letter. After the expiry of this period of 14 calendar days (in the event of a contract being concluded outside the offices), the client can no longer simply renege on the agreement.
+## Article 1 – Scope of Application
 
-2.3. The prices in Stroohm’s quotations are calculated on the basis of the information provided by the Client. Stroohm always reserves the right to adjust its prices if the information provided by the Client is incomplete, inaccurate or incorrect. This applies without prejudice to the method of determining the price and even in the case of an absolute lump sum.
+1.1 These general terms and conditions apply to all quotations, orders, advice, projects and agreements with and by STROOHM BV, with registered office at 2627 Schelle, Interescautlaan 100 bus 2.12, CBE no. 0716.755.863 (hereinafter “STROOHM”). They form an integral part of every agreement concluded with the Client and are deemed to be known and accepted by the Client.
 
-2.4. Changes, additional work and/or more materials, as well as all other orders or services that are not included in the quotation, will in any case be charged separately and on a time and materials basis at an hourly rate of EUR 65.00/hour (per hour started) and travel costs at EUR 0.75/km. The hours and kilometres run from departure from our company headquarters to return to our headquarters.
+1.2 The general terms and conditions of the Client are expressly excluded, even if communicated after notification of the present terms. The special conditions of STROOHM always take precedence over its general terms and conditions, to the extent they deviate therefrom.
 
-2.5. The Customer is advised that the following items are never included in the prices unless expressly agreed otherwise in writing:
+1.3 These terms and conditions do not apply to the use of the digital charging platform (Monta), subscriptions to platform services and energy consumption. These are invoiced directly by Monta ApS to the Client and end users and are subject to the terms and conditions of Monta, available at https://app.monta.app/terms-and-conditions.
 
-## Article 3: Price revision clause
+## Article 2 – Quotations and Prices
 
-3.1. In order to absorb any price fluctuations in materials and raw materials, each agreement will provide for the possibility of revising prices upon simple written request in accordance with the following formula:  
-`P=p {a + (c x (l/i) ) }`  
+2.1 All our price quotations, prices and/or other information stated in price lists, catalogues, correspondence and other documents are drawn up in good faith but approximately, based on current prices. Our prices and offers are non-binding and without any commitment towards the Client. The quotation only binds STROOHM upon legally valid signature by the Client and by a director of STROOHM. All prices are exclusive of VAT, unless otherwise stated. STROOHM’s quotations are valid for a maximum of thirty (30) working days. All statutory charges and taxes are borne by the Client.
 
-Where:  
-P = the new price  
-p = the original price provided for in the quotation  
-a = the percentage of the price that is not eligible for revision (a>=0.20)  
-c = the percentage of material costs in the total price (a + c = 1)  
-l = the new material index* (the month preceding the completion of the works)  
-i = the original material index* (the month preceding the date of the quotation)  
+2.2 In accordance with the statutory provisions, the Client who cannot be considered a business has the right to cancel the agreement within 14 calendar days from the day following signature, without stating a reason and without compensation, provided that this agreement was signed outside the offices of STROOHM. This cancellation must be done by registered letter.
 
-*Material index means: Index I 2021 (see [https://economie.fgov.be/nl/themas/ondernemingen/specifiekesectoren/bouw/prijsherzieningsindexen/mercuriale-index-i-2021](https://economie.fgov.be/nl/themas/ondernemingen/specifiekesectoren/bouw/prijsherzieningsindexen/mercuriale-index-i-2021)).
+2.3 The prices in STROOHM’s quotations are calculated on the basis of the information provided by the Client. STROOHM reserves the right to adjust its prices if the information provided is incomplete, inaccurate or incorrect.
 
-3.2. If the Parties agree that the Customer will advance the full cost price of the materials, the revision clause will apply until receipt of this advance. From this moment on, Stroohm will bear the risk of any price increases. However, the aforementioned does not apply in the case of a general advance as determined in article 9.1.
+2.4 Modifications, additional works and/or additional materials, as well as all other assignments or services not included in the quotation, are charged separately and on a time-and-materials basis at an hourly rate of EUR 95.00/h (per commenced hour) and travel costs at EUR 0.75/km. Hours and kilometres are calculated from departure from our registered office to return to our office.
 
-## Article 4: delivery and execution periods
+2.5 STROOHM has the right to adjust its prices quarterly for ongoing agreements and communicates the new prices at least one month before they take effect. If the Client does not agree, they have the right to terminate the Agreement with immediate effect, provided this is done within 8 days of receipt of the price change notification.
 
-4.1. Unless otherwise agreed in writing, the delivery and execution periods should be regarded as purely informative. They have been drawn up in good faith but are approximate. In any case, the estimated periods will only commence once Stroohm has received all approved plans and/or all other documentation necessary for the execution of the order from the Customer.
+## Article 3 – Price Revision Clause
 
-4.2. The Customer is expressly informed that all stated or agreed periods are indicative. Any delays in execution due to circumstances beyond Stroohm’s control or due to circumstances beyond Stroohm’s control will result in a suspension of Stroohm’s obligations, whereby the Customer waives any right to recover damages resulting from these delays. These include, but are not limited to: delays due to circumstances such as fire, strike, lockout, explosion, heavy snowfall, flooding, machine breakdown, shortage of motive power, raw materials, equipment, workers or means of transport, accidents, exceptional traffic disruption, import and export restrictions, etc. The Customer has the right to terminate the agreement in whole or in part and with immediate effect in writing if the situation referred to in this article 4.2. has occurred for 40 consecutive days.
+3.1 In order to absorb possible price fluctuations in materials and raw materials, each agreement provides for the possibility of revising prices upon written request in accordance with the formula: P = p {a + (c × (l/i))}, where: P = the new price; p = the original price provided in the quotation; a = the percentage of the price not subject to revision (a ≥ 0.20); c = the percentage of material costs in the total price (a + c = 1); l = the new material index (the month preceding the completion of the works); i = the original material index (the month preceding the date of the quotation). The material index used is: Index I 2021 (see https://economie.fgov.be).
 
-4.3. Changes to orders automatically mean that the initially set delivery and execution times will lapse and will be subject to an adjustment, both in price and delivery time, in proportion to the requested change.
+3.2 When the parties agree that the Client advances the full cost of the materials, the price revision clause applies until receipt of this advance payment. From that moment on, STROOHM bears the risk of any price increases.
 
-## Article 5: execution modalities
+## Article 4 – Delivery and Execution Timeframes
 
-5.1. The Customer must ensure that the site is normally accessible and accessible with sufficient manoeuvring and parking facilities, and must clear the site of any obstacles, litter or the like.
+4.1 Unless otherwise agreed in writing, delivery and execution timeframes are to be regarded as purely indicative. They are drawn up in good faith but approximately. The estimated timeframes only commence once STROOHM has received all approved plans and/or all other documentation necessary for execution.
 
-5.2. Electricity must be provided, which is made available free of charge by the Customer. The Customer confirms that the electrical installation complies with the AREI.
+4.2 All delays in execution due to circumstances not attributable to STROOHM result in a suspension of STROOHM’s obligations, whereby the Client waives any right to claim damages. These include, among others: fire, strike, lock-out, explosions, heavy snowfall, floods, machine breakdowns, scarcity of raw materials or labour, accidents, import and export restrictions.
 
-5.3. Stroohm is not responsible for providing a safety coordinator and/or asbestos inventory. If the site is monitored/supervised by an inspection body, we must take note of this in advance.
+4.3 The Client has the right, in the event of force majeure that has lasted for 40 consecutive days, to terminate the agreement as a whole or in part with immediate effect by written notice.
 
-5.4. The costs resulting from failure to comply with articles 5.1. to 5.3. by the Customer, will be charged to the Customer.
+4.4 Changes to orders automatically result in the initially planned delivery and execution timeframes lapsing and being subject to adjustment, both in terms of price and delivery timeframe.
 
-5.5. The parties acknowledge that Stroohm provides very specific services, which are the core of its business. Protecting them is essential. For this reason, the Customer undertakes not to carry out any activities, directly or via an affiliated company or third parties, that would compete with the services/works provided by Stroohm under this agreement, limited to the territory of the Benelux. This obligation applies until three years after the last work carried out by Stroohm for the Customer. Any violation of the provisions of this article 5.5., will be sanctioned with a fixed compensation of EUR 20,000.00 owed by the Customer to Stroohm, without prejudice to Stroohm’s right to greater compensation if it provides proof of its damage.
+## Article 5 – Terms of Execution
 
-## Article 6: Transfer of ownership and risk
+5.1 The Client must ensure that the worksite is normally accessible and reachable with sufficient manoeuvring and parking facilities, and must clear the worksite of any obstacles. Electrical power must be provided, made available free of charge by the Client. The Client confirms that the electrical installation complies with the AREI (Belgian General Regulations for Electrical Installations).
 
-6.1. The Customer becomes the owner of the goods, installations and materials delivered and processed by Stroohm at the moment that the Customer has fulfilled all payment obligations towards Stroohm, including those arising from other transactions. The Customer acknowledges that this retention of title clause has been brought to his attention and accepted by him before the delivery of the goods subject to it. In view of the retention of title, the Customer is prohibited from alienating the sold goods, installations and materials before full payment, under penalty of an additional fixed compensation, equal to half the price of the goods delivered. If the Customer nevertheless proceeds to alienate to a third party in spite of this retention of title, then, in application of article 1690 B.W., all claims arising from this sale shall automatically and without notice of default be transferred to Stroohm as holder of the retention of title, this as security for full payment by the Customer.
+5.2 STROOHM does not provide a safety coordinator and/or asbestos inventory. The costs resulting from the Client’s non-compliance with Article 5.1 shall be charged to the Client.
 
-6.2. From the moment of delivery of the goods, materials and installations by Stroohm to and on the premises of or designated by the Customer, the Customer is solely responsible for any risk, including cases of force majeure and total or partial destruction, loss, theft, damage or loss, notwithstanding the retention of title.
+5.3 The earthing of the property falls outside the works carried out by STROOHM, meaning STROOHM is never liable for a rejection due to non-compliant earthing by the independent inspection authority.
 
-## Article 7: defects and non-conformity
+5.4 STROOHM’s services are performed either by STROOHM itself or by a competent subcontractor of STROOHM. STROOHM remains the point of contact for the Client in all cases.
 
-7.1. Stroohm is obliged to carry out all works in accordance with the agreement and the rules of good art.
+5.5 The Client undertakes not to engage, directly or through an affiliated company or third parties, in any activities that would compete with the services/works provided by STROOHM, limited to the territory of the Benelux and for a period of three years after the last works. Any breach shall be sanctioned with a lump-sum penalty of EUR 20,000.00.
 
-7.2. Complaints regarding visible defects or non-conformity must be reported in writing by the Customer to Stroohm within eight calendar days after installation, failing which the works are deemed to have been accepted.
+5.6 The Client undertakes, for up to three years after the last works, not to approach any STROOHM employees, directly or indirectly, for employment purposes. Any breach shall be sanctioned with a lump-sum penalty of EUR 20,000.00.
 
-7.3. Complaints regarding hidden defects must be reported to Stroohm within eight calendar days after discovery, failing which the Customer is deemed to have accepted the defects. Stroohm’s liability for minor hidden defects that do not fall within the scope of the ten-year liability in accordance with articles 1792 and 2270 of the Civil Code is in any case limited to a period of twelve (12) months after completion of the works by Stroohm, unless otherwise agreed in the special conditions or a guarantee agreement. If there is a factory guarantee, this applies, without it being possible to be more extensive. Any legal action on the basis of these minor hidden defects must also be instituted no later than six (6) months after the discovery of the defect, under penalty of forfeiture.
+## Article 6 – The Charging Platform and Role of Monta
 
-7.4. The burden of proof of the alleged hidden defects lies with the Customer. Any claim for indemnity shall in any case lapse in the event of processing, modification or repair by the Customer or any third party appointed by him for this purpose. The parties confirm that the Customer’s waiting for an inspection of the works by a specific third party is not a reason to withhold any payment obligation towards Stroohm.
+6.1 STROOHM works with Monta ApS as platform operator for digital management services. The digital charging platform and the associated mobile application are made available directly by Monta to the Client and end users. Monta acts as an independent contracting party for the Client and end users with regard to platform use, subscriptions and energy consumption.
 
-## Article 8: Liability
+6.2 Platform subscriptions and energy consumption are invoiced directly by Monta to the Client, using Monta’s VAT number. STROOHM is not a party to the payment relationship between Monta and the Client.
 
-8.1. Stroohm is bound to the Client by means of an obligation of best efforts, unless expressly agreed otherwise in writing. Any unforeseen damage to interior or exterior finishing cannot be ruled out and is not the responsibility of Stroohm.
+6.3 End users (EV drivers) accept Monta’s terms of use and privacy policy upon registration. These are available at:
+- Monta Terms of Use: https://app.monta.app/terms-and-conditions
+- Monta Privacy Policy: https://app.monta.app/privacy-policy
 
-8.2. The storage of the works is always at the risk of the Client.
+6.4 STROOHM is not liable for the operation, availability or modifications of the Monta platform, nor for disruptions to platform services or invoices issued by Monta. For complaints regarding the platform, subscriptions or energy invoicing, the Client must contact Monta directly.
 
-8.3. The contractor is not liable if the client has not ensured the production of copies, backup copies and other such duplicates of the documents provided to the contractor, if the production thereof could reasonably be expected of the client.
+6.5 The Client is informed that prompt payment of Monta’s invoices is necessary. Since STROOHM bears responsibilities towards Monta, all services of both STROOHM and Monta may be suspended if Monta’s invoices remain unpaid for more than 14 days after the due date, without any prior notice of default being required.
 
-8.4. Damage during the execution of the works to windows, doors and walls, … that is the result of the Client’s careless shielding thereof, cannot be charged to Stroohm.
+## Article 7 – Transfer of Ownership and Risk
 
-8.5. Stroohm’s liability in the event of proven liability for which Stroohm must be responsible is in any case always limited to the amount of the work performed. In no event can the following damage be recovered from Stroohm: 
-- any possible indirect damage that the Customer may suffer as a result of non-compliance with the agreement, such as but not limited to: financial and commercial loss, loss of production, loss of profit, increase in general costs, disruption of planning, loss of clientele, damage to reputation, etc. 
-- damage that the Customer may suffer as a result of claims or demands from third parties.
+7.1 The Client becomes the owner of the goods, installations and materials supplied and processed by STROOHM at the moment the Client has fulfilled all payment obligations towards STROOHM. Given the retention of title, the Client is prohibited from transferring the sold goods, installations and materials before full payment.
 
-8.6. The earthing of the home is located outside the works carried out by Stroohm, as a result of which Stroohm is never liable for a rejection due to non-compliant earthing by the independent inspection body.
+7.2 From the delivery of the goods, materials and installations by STROOHM to the Client’s premises, it is solely the Client who bears all risk, including cases of force majeure and total or partial destruction, loss, theft, damage or disappearance.
 
-## Article 9: payment terms
+## Article 8 – Defects and Non-Conformity
 
-9.1. The invoicing of the goods and works will be done as follows, unless otherwise agreed in writing: 
-- advance invoice of 35% upon acceptance of the quotation (only if the amount of the works is greater than € 4,000.00); 
-- a subsequent advance invoice of 35%: 1 month before the start of the works. 
-- the balance of 30% after the installation has been completed (= before the inspection). Additional or reduced works will also be settled in this.
+8.1 STROOHM is obliged to carry out all works in accordance with the agreement and the rules of good workmanship.
 
-9.2. Unless otherwise agreed in writing, Stroohm’s invoices are payable in cash, net and without discount or debt settlement no later than thirty (30) days after the invoice date at the address of its registered office or into the bank account to be designated by it. Appointees are not authorised to receive payments.
+8.2 Complaints regarding visible defects or non-conformity must be reported in writing by the Client to STROOHM within eight calendar days of installation at the latest, failing which the works are deemed to have been accepted.
 
-9.3. Complaints regarding the invoice must be submitted by registered and motivated letter within eight (8) days after the invoice date, failing which the invoice will be considered accepted.
+8.3 Complaints regarding hidden defects must be reported to STROOHM within eight calendar days of discovery at the latest. STROOHM’s liability for minor hidden defects is limited to a period of twelve (12) months after completion of the works, unless otherwise agreed in the special conditions or a warranty agreement.
 
-9.4. In the event of late payment, default interest of 12% per year will be due on the invoice amount or the outstanding balance by operation of law and without notice of default, calculated from the due date. In the event of full or partial non-payment of the debt on the due date, after a notice of default has been given in vain, the outstanding balance will be increased by way of fixed compensation by 12% with a minimum of € 250, even if grace periods are granted. Legal costs and other collection costs will be borne by the Customer.
+8.4 The burden of proof of the alleged hidden defects rests with the Client. Any claim for warranty lapses upon processing, modification or repair by the Client or by third parties appointed by them.
 
-9.5. Failure to pay an invoice on the due date will result in the forfeiture of the payment deferral that would have been allowed for other deliveries and will make all invoices that have not yet expired immediately payable.
+## Article 9 – Liability
 
-## Article 10: intellectual property and copyrights
+9.1 STROOHM is bound to the Client by a best-efforts obligation, unless expressly otherwise agreed in writing.
 
-10.1. All documents provided by the parties to each other, such as reports, advice, agreements, designs, sketches, drawings, software, etc., are exclusively intended to be used in the context of this agreement and may not be reproduced, made public or brought to the attention of third parties by them without the prior consent of the other party, unless the nature of the documents provided dictates otherwise.
+9.2 The custody of the works is always at the risk of the Client.
 
-10.2. Stroohm reserves the right to use the knowledge acquired through the performance of the work for other purposes, provided that no confidential information is brought to the attention of third parties.
+9.3 STROOHM is not liable if the Client has failed to ensure the creation of copies, backup copies and other such duplicates of documents provided to STROOHM or during the works carried out by STROOHM, where the creation thereof could reasonably have been required of the Client.
 
-10.3. Stroohm has the right to mention drawings and photos of the services provided to the Client on its website, to show them during presentations or to mention them in other commercial applications.
+9.4 Damage during the execution of the works to windows, doors, walls, … resulting from inadequate protection by the Client cannot be charged to STROOHM.
 
-10.4. Stroohm keeps certain data of the Client, for administrative reasons as well as for the performance of the agreement itself, and also for sending commercial information. The Customer has the right to request access to this data or to have it changed/deleted, via info@stroohm-services.be.
+9.5 In the event of proven liability, STROOHM’s liability shall in all cases be limited to the amount of the works performed. Under no circumstances can the following damages be recovered from STROOHM: indirect damages, financial and commercial losses, production losses, loss of profit, increase in general costs, disruption of planning, loss of customers or damage to reputation, or damages suffered by the Customer as a result of claims by third parties.
 
-## Article 11 – Force Majeure
+9.6 STROOHM is not liable for damage resulting from the operation, availability or security of the Monta platform, platform subscriptions or energy invoicing by Monta.
 
-11.1. If Stroohm is unable to fulfil its obligations under the agreement, or is unable to fulfil them in a timely or proper manner, due to a cause beyond its control, including but not limited to: war, threat of war, civil war, riot, unrest, terrorism, strikes, occupation of premises, exclusion, fire, environmental and water damage, flooding, government measures, disruptions in the supply of energy and business supplies, sudden incapacity for work of employees, disruptions in any network and other events that could lead to stagnation in its activities and that cannot reasonably be borne by Stroohm or be at its own risk, those obligations will be suspended until Stroohm is able to fulfil them in the agreed manner, without Stroohm being in default with regard to the fulfilment of its obligations and without being liable for any damages.
+## Article 10 – Payment Terms
 
-11.2. In the event of force majeure, Stroohm, if applicable, has the right to offer another equivalent charging point.
+10.1 The invoicing of goods and works by STROOHM is as follows, unless otherwise agreed in writing: an advance invoice of 35% upon acceptance of the quotation (only if the amount exceeds € 4,000.00); a further advance invoice of 35% one month before the commencement of works; the balance of 30% after the installation is completed, prior to inspection.
 
-11.3. The Customer has the right, if the situation referred to in Article 11.1. has occurred for 40 consecutive days, to terminate the agreement in writing in whole or in part and with immediate effect.
+10.2 Unless otherwise agreed in writing, STROOHM’s invoices are payable in cash, net and without discount or set-off, within thirty (30) days of the invoice date at the latest.
 
-## Article 12: Suspension – extrajudicial dissolution
+10.3 Complaints regarding an invoice must be submitted by registered and substantiated letter within eight (8) days of the invoice date, on pain of forfeiture, failing which the invoice is deemed to have been accepted.
 
-12.1. Any termination, termination or cancellation of an order or contract, as well as the failure to comply with the agreed payment conditions or any other material breach of contract by one of the parties, gives the other party the right to suspend its further performance and/or obligations towards this party. In that case, Stroohm can only resume the suspended performance after regularisation by the Customer in accordance with the obligations it has entered into with other Customers in the meantime.
+10.4 In the event of late payment, default interest of 12% per year shall be due by operation of law and without notice of default, calculated from the due date. In the event of full or partial non-payment, the outstanding balance shall be increased by way of a lump-sum penalty of 12% with a minimum of € 250. Court costs and collection costs are borne by the Client.
 
-12.2. A party optionally has the right, when Article 12.1. of these general terms and conditions apply and after written notice of default, to consider all contracts entered into with the other party as wholly or partially dissolved, without judicial intervention, without compensation for the other party and this without prejudice to the right to compensation, the minimum of which is set at a fixed rate of 30% of the agreed price, the excess to be proven by the injured Party.
+10.5 Failure to pay on the due date renders all outstanding invoices immediately due and payable and gives STROOHM the right to suspend further services.
 
-12.3. If, during the execution of the agreement, the financial situation of a party changes to such an extent that there is a fear of insolvency, loss of guarantees for its claim or if a party is declared in liquidation or bankruptcy, the other party has the right, after written notice of default, to terminate the agreement without judicial intervention. In that case, the other party is entitled to compensation, as stated in article 12.2.
+## Article 11 – Intellectual Property and Copyrights
 
-## Article 13: competent court – applicable law
+11.1 All documents provided by the parties to each other, such as reports, advice, agreements, designs, sketches, drawings and software, are intended exclusively for use within the framework of this agreement and may not be reproduced, disclosed or brought to the attention of third parties without the prior consent of the other party.
 
-13.1. Any dispute, of whatever nature, will be settled by the territorially and materially competent court of the registered office of Stroohm.
+11.2 STROOHM retains the right to use knowledge acquired through the execution of the works for other purposes, provided that no confidential information is disclosed to third parties.
 
-13.2. Only Belgian law applies in this case.
+11.3 STROOHM shall have the right to display drawings and photographs of the services performed for the Customer on its website, during presentations, or in other commercial applications.
 
-## Article 14: Right of withdrawal
+## Article 12 – Data Protection
 
-Only a Consumer has a period of 14 days to withdraw from a Distance Contract relating to the purchase of goods or services without giving reasons. 
-The 14-day period commences on the day the goods are delivered or, in the case of services, the Agreement was concluded. The Consumer must inform STROOHM unambiguously by email (at the following address info@stroohm.be) of his/her decision to cancel the purchase of the goods or services before the 14-day period has expired. The Consumer will then receive instructions on how to return the Charging Card to STROOHM, at his/her own expense. 
-If the Consumer has allowed the delivery of services to commence during the cancellation period, he/she will pay an amount that is either proportional to what has already been delivered at the time of cancellation in comparison with the full performance of the agreement, or, if possible to identify this, corresponds to the specific services that were purchased.
+12.1 STROOHM processes personal data of the Client and their contact persons as data controller, exclusively for the performance of the agreement, customer management and accounting. The STROOHM Privacy Statement is available at www.stroohm.com and will be provided upon request.
+
+12.2 The Client has the right to request access to their data or to have it modified/deleted, via privacy@stroohm.com.
+
+12.3 For the processing of personal data by Monta in the context of the platform, STROOHM refers to Monta’s privacy policy at https://app.monta.app/privacy-policy. Monta is the independent data controller for this purpose.
+
+## Article 13 – Force Majeure
+
+13.1 If STROOHM is unable to fulfil its obligations, or unable to do so on time or properly, due to a cause not attributable to it — including but not limited to: war, terrorism, strike, fire, environmental and water damage, flooding, government measures, disruptions to energy supply, sudden incapacity of employees, or network disruptions — those obligations are suspended until STROOHM is able to fulfil them, without STROOHM being in default or liable for damages.
+
+13.2 The Client has the right to terminate the agreement in writing if the force majeure situation persists for more than 40 consecutive days.
+
+## Article 14 – Suspension and Extrajudicial Termination
+
+14.1 Any cancellation, termination or annulment of an order or contract, or failure to comply with payment terms or any other material breach, entitles the other party to suspend its further services.
+
+14.2 A party has the right, when Article 14.1 applies and after written notice of default, to consider all contracts entered into with the other party as dissolved in whole or in part, without judicial intervention and without prejudice to the right to damages of at least 30% of the agreed price.
+
+14.3 If, in the course of execution, the financial situation of a party changes to such an extent that insolvency must be feared, the other party has the right, after written notice of default, to dissolve the agreement without judicial intervention.
+
+## Article 15 – Competent Court and Applicable Law
+
+15.1 Any dispute, of whatever nature, shall be settled by the territorially and materially competent court of the registered office of STROOHM (district of Antwerp).
+
+15.2 Belgian law exclusively applies, with the express exclusion of the Vienna Convention on Contracts for the International Sale of Goods of 11 April 1980.
+
+### Contact Details
+
+- **Name:** STROOHM BV
+- **Company registration no.:** 0716.755.863
+- **Address:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **General Email:** info@stroohm.com
+- **Privacy Email:** privacy@stroohm.com
+- **Website:** www.stroohm.com
+
+_These General Terms and Conditions were last updated on 18 May 2026._
+
+---
+
+# STROOHM Conditions Générales (Français)
+
+**Conditions Générales d’Installation et de Gestion**
+
+- **Date :** Mai 2026
+- **Responsable :** STROOHM BV
+- **Numéro BCE :** 0716.755.863
+- **Siège social :** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Contact :** info@stroohm.com
+
+> **Champ d’application :** les présentes conditions générales régissent exclusivement les services que STROOHM BV fournit directement au Client : l’installation d’infrastructure de recharge, la maintenance, la gestion et les services connexes. L’utilisation de la plateforme de recharge numérique (Monta ou autre fournisseur) et la facturation des abonnements et de la consommation d’énergie sont soumises aux conditions de Monta ApS (ou autre fournisseur), qui relient directement le Client et les utilisateurs finals à Monta (ou autre fournisseur).
+
+## Article 1 – Champ d’application
+
+1.1 Les présentes conditions générales s’appliquent à tous les devis, commandes, conseils, projets et contrats conclus avec et par STROOHM BV, dont le siège social est établi à 2627 Schelle, Interescautlaan 100 bus 2.12, BCE n° 0716.755.863 (ci-après « STROOHM »). Elles font partie intégrante de tout contrat conclu avec le Client et sont réputées connues et acceptées par celui-ci.
+
+1.2 Les conditions générales du Client sont expressément exclues, même si elles sont communiquées après notification des présentes conditions. Les conditions particulières de STROOHM priment toujours sur ses conditions générales, dans la mesure où elles y dérogent.
+
+1.3 Les présentes conditions ne s’appliquent pas à l’utilisation de la plateforme de recharge numérique (Monta), aux abonnements aux services de plateforme et à la consommation d’énergie. Ceux-ci sont facturés directement par Monta ApS au Client et aux utilisateurs finals et sont soumis aux conditions de Monta, consultables via https://app.monta.app/terms-and-conditions.
+
+## Article 2 – Devis et prix
+
+2.1 Tous nos devis, prix et/ou autres informations mentionnés dans les listes de prix, catalogues, correspondances et autres documents sont établis de bonne foi mais à titre indicatif, sur la base des prix en vigueur. Nos prix et offres sont sans engagement et sans aucune obligation envers le Client. Le devis n’engage STROOHM qu’après signature valide par le Client et par un administrateur de STROOHM. Tous les prix sont hors TVA, sauf mention contraire. Les devis de STROOHM sont valables trente (30) jours ouvrables au maximum. Toutes les charges légales et taxes sont à la charge du Client.
+
+2.2 Conformément aux dispositions légales, le Client qui ne peut être considéré comme une entreprise dispose du droit de résilier le contrat dans les 14 jours civils suivant la signature, sans indication de motif et sans indemnité, pour autant que ce contrat ait été signé en dehors des bureaux de STROOHM. Cette résiliation doit être effectuée par lettre recommandée.
+
+2.3 Les prix figurant dans les devis de STROOHM sont calculés sur la base des informations fournies par le Client. STROOHM se réserve le droit d’ajuster ses prix si les informations fournies sont incomplètes, inexactes ou erronées.
+
+2.4 Les modifications, travaux supplémentaires et/ou matériaux supplémentaires, ainsi que toutes autres missions ou services non inclus dans le devis, sont facturés séparément en régie à un tarif horaire de 95,00 EUR/h (par heure entamée) et les frais de déplacement à 0,75 EUR/km. Les heures et kilomètres sont comptés depuis le départ de notre siège social jusqu’au retour à notre siège.
+
+2.5 STROOHM a le droit d’ajuster ses prix trimestriellement pour les contrats en cours et communique ces nouveaux prix au plus tard un mois avant leur entrée en vigueur. Si le Client n’est pas d’accord, il a le droit de résilier le Contrat avec effet immédiat, pour autant que cela intervienne dans les 8 jours suivant la réception de la notification de modification de prix.
+
+## Article 3 – Clause de révision des prix
+
+3.1 Afin d’absorber d’éventuelles fluctuations de prix des matériaux et des matières premières, chaque contrat prévoit la possibilité de réviser les prix sur demande écrite conformément à la formule : P = p {a + (c × (l/i))}, où : P = le nouveau prix ; p = le prix initial prévu dans le devis ; a = le pourcentage du prix non soumis à révision (a ≥ 0,20) ; c = le pourcentage des coûts des matériaux dans le prix total (a + c = 1) ; l = le nouvel indice des matériaux (le mois précédant l’achèvement des travaux) ; i = l’indice original des matériaux (le mois précédant la date du devis). L’indice des matériaux utilisé est : Index I 2021 (voir https://economie.fgov.be).
+
+3.2 Lorsque les parties conviennent que le Client avance le coût intégral des matériaux, la clause de révision des prix s’applique jusqu’à la réception de cet acompte. À partir de ce moment, STROOHM supporte le risque d’éventuelles hausses de prix.
+
+## Article 4 – Délais de livraison et d’exécution
+
+4.1 Sauf accord écrit contraire, les délais de livraison et d’exécution doivent être considérés comme purement indicatifs. Ils sont établis de bonne foi mais à titre approximatif. Les délais estimés ne commencent à courir qu’une fois que STROOHM a reçu tous les plans approuvés et/ou toute autre documentation nécessaire à l’exécution.
+
+4.2 Tous les retards d’exécution dus à des circonstances non imputables à STROOHM entraînent une suspension des obligations de STROOHM, le Client renonçant à tout droit de recours en dommages-intérêts. Cela comprend notamment : incendie, grève, lock-out, explosions, chutes de neige importantes, inondations, pannes de machines, pénurie de matières premières ou de main-d’œuvre, accidents, restrictions à l’importation et à l’exportation.
+
+4.3 Le Client a le droit, en cas de force majeure ayant duré 40 jours consécutifs, de résilier le contrat en tout ou en partie avec effet immédiat par notification écrite.
+
+4.4 Les modifications des commandes entraînent automatiquement la caducité des délais de livraison et d’exécution initialement prévus, qui feront l’objet d’un ajustement tant en termes de prix que de délai de livraison.
+
+## Article 5 – Modalités d’exécution
+
+5.1 Le Client doit s’assurer que le chantier est normalement accessible et atteignable avec suffisamment d’espace de manœuvre et de stationnement, et doit dégager le chantier de tout obstacle. Une alimentation électrique doit être prévue, mise à disposition gratuitement par le Client. Le Client confirme que l’installation électrique est conforme au RGIE (Règlement Général sur les Installations Électriques).
+
+5.2 STROOHM ne prend pas en charge la mise à disposition d’un coordinateur de sécurité et/ou d’un inventaire amiante. Les coûts résultant du non-respect de l’article 5.1 par le Client seront répercutés sur celui-ci.
+
+5.3 La mise à la terre de l’habitation est en dehors des travaux réalisés par STROOHM, de sorte que STROOHM ne peut jamais être tenu responsable d’un refus de réception pour cause de mise à la terre non conforme par l’organisme de contrôle indépendant.
+
+5.4 Les prestations de STROOHM sont exécutées soit par STROOHM elle-même, soit par un sous-traitant compétent de STROOHM. STROOHM reste dans tous les cas l’interlocuteur du Client.
+
+5.5 Le Client s’engage à ne pas exercer, directement ou par l’intermédiaire d’une société liée ou de tiers, des activités qui seraient en concurrence avec les prestations/travaux fournis par STROOHM, limité au territoire du Benelux et pendant trois ans après les derniers travaux. Toute infraction sera sanctionnée par une indemnité forfaitaire de 20 000,00 EUR.
+
+5.6 Le Client s’engage, jusqu’à trois ans après les derniers travaux, à ne pas approcher les membres du personnel de STROOHM, directement ou indirectement, en vue de les engager. Toute infraction sera sanctionnée par une indemnité forfaitaire de 20 000,00 EUR.
+
+## Article 6 – La plateforme de recharge et le rôle de Monta
+
+6.1 STROOHM collabore avec Monta ApS en tant qu’opérateur de plateforme pour les services de gestion numérique. La plateforme de recharge numérique et l’application mobile associée sont mises à disposition directement par Monta au Client et aux utilisateurs finals. Monta agit en tant que partie contractante indépendante pour le Client et les utilisateurs finals en ce qui concerne l’utilisation de la plateforme, les abonnements et la consommation d’énergie.
+
+6.2 Les abonnements à la plateforme et la consommation d’énergie sont facturés directement par Monta au Client, avec le numéro de TVA de Monta. STROOHM n’est pas partie à la relation de paiement entre Monta et le Client.
+
+6.3 Les utilisateurs finals (conducteurs de véhicules électriques) acceptent les conditions d’utilisation et la politique de confidentialité de Monta lors de leur inscription. Celles-ci sont consultables via :
+- Conditions d’utilisation Monta : https://app.monta.app/terms-and-conditions
+- Politique de confidentialité Monta : https://app.monta.app/privacy-policy
+
+6.4 STROOHM n’est pas responsable du fonctionnement, de la disponibilité ou des modifications de la plateforme Monta, ni des interruptions des services de la plateforme ou des factures émises par Monta. Pour les réclamations concernant la plateforme, les abonnements ou la facturation de l’énergie, le Client doit s’adresser directement à Monta.
+
+6.5 Le Client est informé que le paiement ponctuel des factures de Monta est nécessaire. Étant donné que STROOHM assume des responsabilités envers Monta, toutes les prestations tant de STROOHM que de Monta peuvent être suspendues si les factures de Monta restent impayées plus de 14 jours après la date d’échéance, sans qu’une mise en demeure préalable ne soit nécessaire.
+
+## Article 7 – Transfert de propriété et des risques
+
+7.1 Le Client devient propriétaire des marchandises, installations et matériaux fournis et traités par STROOHM au moment où le Client a rempli toutes ses obligations de paiement envers STROOHM. Compte tenu de la réserve de propriété, il est interdit au Client de céder les marchandises, installations et matériaux vendus avant paiement intégral.
+
+7.2 Dès la livraison des marchandises, matériaux et installations par STROOHM sur les terrains du Client, c’est exclusivement le Client qui assume tous les risques, y compris les cas de force majeure et la destruction totale ou partielle, la perte, le vol, les dégâts ou la disparition.
+
+## Article 8 – Défauts et non-conformité
+
+8.1 STROOHM est tenue d’exécuter tous les travaux conformément au contrat et aux règles de l’art.
+
+8.2 Les réclamations concernant les défauts apparents ou la non-conformité doivent être signalées par écrit par le Client à STROOHM au plus tard dans les huit jours civils suivant la pose, à défaut de quoi les travaux sont réputés acceptés.
+
+8.3 Les réclamations concernant les défauts cachés doivent être signalées à STROOHM au plus tard dans les huit jours civils suivant leur découverte. La responsabilité de STROOHM pour les défauts cachés mineurs est limitée à une période de douze (12) mois après l’achèvement des travaux, sauf accord contraire dans les conditions particulières ou un contrat de garantie.
+
+8.4 La charge de la preuve des défauts cachés allégués incombe au Client. Toute demande de garantie devient caduque en cas de transformation, de modification ou de réparation par le Client ou par des tiers désignés par lui.
+
+## Article 9 – Responsabilité
+
+9.1 STROOHM est liée au Client par une obligation de moyens, sauf accord express contraire écrit.
+
+9.2 La garde des travaux s’effectue toujours aux risques du Client.
+
+9.3 STROOHM n’est pas responsable si le Client n’a pas veillé à la réalisation de copies, de sauvegardes et autres duplicata des documents remis à STROOHM ou lors des travaux exécutés par STROOHM, lorsqu’on pouvait raisonnablement l’exiger du Client.
+
+9.4 Les dommages causés aux fenêtres, portes, murs, … lors de l’exécution des travaux et résultant d’une protection insuffisante par le Client ne peuvent être mis à charge de STROOHM.
+
+9.5 En cas de responsabilité prouvée, la responsabilité de STROOHM sera en tout état de cause limitée au montant des travaux exécutés. En aucun cas les dommages suivants ne pourront être imputés à STROOHM : dommages indirects, pertes financières et commerciales, pertes de production, manque à gagner, augmentation des frais généraux, perturbation du planning, perte de clientèle ou atteinte à la réputation, ainsi que les dommages subis par le Client à la suite de réclamations de tiers.
+
+9.6 STROOHM n’est pas responsable des dommages résultant du fonctionnement, de la disponibilité ou de la sécurité de la plateforme Monta, des abonnements à la plateforme ou de la facturation de l’énergie par Monta.
+
+## Article 10 – Modalités de paiement
+
+10.1 La facturation des biens et travaux par STROOHM s’effectue comme suit, sauf accord écrit contraire : facture d’acompte de 35 % à l’acceptation du devis (uniquement si le montant dépasse € 4 000,00) ; une nouvelle facture d’acompte de 35 % un mois avant le début des travaux ; le solde de 30 % après l’achèvement de l’installation, avant l’inspection.
+
+10.2 Sauf accord écrit contraire, les factures de STROOHM sont payables au comptant, net et sans remise ni compensation, dans les trente (30) jours suivant la date de facturation au plus tard.
+
+10.3 Les réclamations concernant la facture doivent être adressées par lettre recommandée et motivée dans les huit (8) jours suivant la date de facturation, sous peine de déchéance, à défaut de quoi la facture est réputée acceptée.
+
+10.4 En cas de paiement tardif, un intérêt de retard de 12 % par an sera dû de plein droit et sans mise en demeure, calculé à partir de la date d’échéance. En cas de non-paiement total ou partiel, le solde dû sera augmenté à titre d’indemnité forfaitaire de 12 % avec un minimum de € 250. Les frais judiciaires et de recouvrement sont à la charge du Client.
+
+10.5 Le défaut de paiement à la date d’échéance rend toutes les factures non encore échues immédiatement exigibles et donne à STROOHM le droit de suspendre l’exécution de ses prestations.
+
+## Article 11 – Propriété intellectuelle et droits d’auteur
+
+11.1 Tous les documents fournis par les parties l’une à l’autre, tels que rapports, conseils, contrats, projets, esquisses, plans et logiciels, sont destinés exclusivement à être utilisés dans le cadre du présent contrat et ne peuvent être reproduits, divulgués ou portés à la connaissance de tiers sans le consentement préalable de l’autre partie.
+
+11.2 STROOHM conserve le droit d’utiliser les connaissances acquises lors de l’exécution des travaux à d’autres fins, pour autant qu’aucune information confidentielle ne soit divulguée à des tiers.
+
+11.3 STROOHM a le droit de publier des dessins et des photographies des prestations réalisées pour le Client sur son site web, de les présenter lors de présentations ou de les utiliser dans le cadre d’autres applications commerciales.
+
+## Article 12 – Protection des données
+
+12.1 STROOHM traite les données à caractère personnel du Client et de ses personnes de contact en tant que responsable du traitement, exclusivement pour l’exécution du contrat, la gestion des clients et la comptabilité. La Déclaration de confidentialité de STROOHM est consultable sur www.stroohm.com et sera fournie sur demande.
+
+12.2 Le Client a le droit de demander l’accès à ses données ou de les faire modifier/supprimer, via privacy@stroohm.com.
+
+12.3 Pour le traitement des données à caractère personnel par Monta dans le cadre de la plateforme, STROOHM renvoie à la politique de confidentialité de Monta via https://app.monta.app/privacy-policy. Monta est le responsable du traitement indépendant à cet égard.
+
+## Article 13 – Force majeure
+
+13.1 Si STROOHM ne peut pas remplir ses obligations, ou ne peut le faire en temps voulu ou de manière adéquate, en raison d’une cause qui ne lui est pas imputable — incluant sans s’y limiter : guerre, terrorisme, grève, incendie, dommages environnementaux et hydrauliques, inondation, mesures gouvernementales, perturbations de l’approvisionnement en énergie, incapacité soudaine de travail des employés ou pannes de réseaux — ces obligations sont suspendues jusqu’à ce que STROOHM soit à nouveau en mesure de les remplir, sans que STROOHM ne soit en défaut ou tenue à des dommages-intérêts.
+
+13.2 Le Client a le droit de résilier le contrat par écrit si la situation de force majeure persiste plus de 40 jours consécutifs.
+
+## Article 14 – Suspension et résiliation extrajudiciaire
+
+14.1 Toute rupture, résiliation ou annulation d’une commande ou d’un contrat, ou le non-respect des conditions de paiement ou tout autre manquement essentiel, donne à l’autre partie le droit de suspendre ses prestations ultérieures.
+
+14.2 Une partie a le droit, lorsque l’article 14.1 est applicable et après mise en demeure écrite, de considérer tous les contrats conclus avec l’autre partie comme résiliés en tout ou en partie, sans intervention judiciaire et sans préjudice du droit à des dommages-intérêts d’au moins 30 % du prix convenu.
+
+14.3 Si, au cours de l’exécution, la situation financière d’une partie se modifie de telle sorte qu’une insolvabilité est à craindre, l’autre partie a, après mise en demeure écrite, le droit de résilier le contrat sans intervention judiciaire.
+
+## Article 15 – Tribunal compétent et droit applicable
+
+15.1 Tout litige, de quelque nature que ce soit, sera réglé par le tribunal territorialement et matériellement compétent du siège social de STROOHM (arrondissement d’Anvers).
+
+15.2 Le droit belge est exclusivement applicable, avec exclusion expresse de la Convention de Vienne sur les contrats de vente internationale de marchandises du 11 avril 1980.
+
+### Coordonnées
+
+- **Nom :** STROOHM BV
+- **Numéro BCE :** 0716.755.863
+- **Adresse :** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **E-mail général :** info@stroohm.com
+- **E-mail confidentialité :** privacy@stroohm.com
+- **Site web :** www.stroohm.com
+
+_Les présentes Conditions Générales ont été mises à jour pour la dernière fois le 18 mai 2026._
+
+---
+
+# STROOHM Algemene Voorwaarden (Nederlands)
+
+**Algemene Voorwaarden Installatie & Beheer**
+
+- **Datum:** Mei 2026
+- **Verantwoordelijke:** STROOHM BV
+- **KBO-nummer:** 0716.755.863
+- **Maatschappelijke zetel:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **Contact:** info@stroohm.com
+
+> **Toepassingsgebied:** deze algemene voorwaarden regelen uitsluitend de diensten die STROOHM BV rechtstreeks aan de Klant levert: de installatie van laadinfrastructuur, onderhoud, beheer en aanverwante diensten. Het gebruik van het digitale laadplatform (Monta of andere leverancier) en de facturatie van abonnementen en energieverbruik zijn onderworpen aan de voorwaarden van Monta ApS (of andere leverancier), die de Klant en de eindgebruikers rechtstreeks met Monta (of andere leverancier) verbinden.
+
+## Artikel 1 – Toepassingsgebied
+
+1.1 Deze algemene voorwaarden zijn van toepassing op alle offertes, bestellingen, adviezen, projecten en overeenkomsten met en door STROOHM BV, met maatschappelijke zetel te 2627 Schelle, Interescautlaan 100 bus 2.12, KBO-nr. 0716.755.863 (hierna "STROOHM"). Zij maken integraal deel uit van elke overeenkomst die met de Klant wordt afgesloten en worden geacht gekend en aanvaard te zijn door de Klant.
+
+1.2 De algemene voorwaarden van de Klant worden uitdrukkelijk uitgesloten, ook al worden zij meegedeeld na kennisgeving van de onderhavige voorwaarden. De bijzondere voorwaarden van STROOHM primeren steeds op haar algemene voorwaarden, voor zover zij er zouden van afwijken.
+
+1.3 Deze voorwaarden zijn niet van toepassing op het gebruik van het digitale laadplatform (Monta), de abonnementen op platformdiensten en het energieverbruik. Die worden rechtstreeks door Monta ApS aan de Klant en eindgebruikers gefactureerd en zijn onderworpen aan de voorwaarden van Monta, raadpleegbaar via https://app.monta.app/terms-and-conditions.
+
+## Artikel 2 – Offertes en prijzen
+
+2.1 Al onze prijsoffertes, de prijzen en/of andere inlichtingen vermeld in prijslijsten, catalogi, briefwisseling en andere stukken zijn te goeder trouw doch bij benadering opgesteld op basis van de gangbare prijzen. Onze prijzen en aanbiedingen zijn vrijblijvend en zonder enige verbintenis ten aanzien van de Klant. De offerte verbindt pas STROOHM mits rechtsgeldige ondertekening door de Klant en door een bestuurder van STROOHM. Alle prijzen zijn exclusief BTW, tenzij anders vermeld. De offertes van STROOHM zijn maximaal dertig (30) werkdagen geldig. Alle wettelijke lasten en taksen vallen ten laste van de Klant.
+
+2.2 Conform de wettelijke bepalingen beschikt de Klant die niet als een onderneming kan worden beschouwd, over het recht om gedurende 14 kalenderdagen vanaf de dag volgend op de ondertekening de overeenkomst op te zeggen zonder opgave van motief en zonder schadevergoeding, voor zover deze overeenkomst ondertekend is buiten de kantoren van STROOHM. Deze opzegging dient per aangetekend schrijven te gebeuren.
+
+2.3 De prijzen in de offertes van STROOHM worden berekend op basis van de door de Klant verstrekte informatie. STROOHM behoudt zich het recht voor haar prijzen aan te passen indien de verstrekte gegevens onvolledig, onnauwkeurig of foutief zijn.
+
+2.4 Wijzigingen, meerwerken en/of meer materialen, alsmede alle andere opdrachten of diensten die niet in de offerte zijn opgenomen, worden afzonderlijk en in regie aangerekend aan een uurtarief van 95,00 EUR/u (per begonnen uur) en verplaatsingskosten aan 0,75 EUR/km. De uren en kilometers lopen van vertrek aan onze firma-zetel tot terugkomst in onze zetel.
+
+2.5 STROOHM heeft het recht haar prijzen per kwartaal aan te passen voor lopende overeenkomsten en communiceert die nieuwe prijzen ten laatste één maand voor het ingaan ervan. Indien de Klant niet akkoord gaat, heeft hij het recht de Overeenkomst met onmiddellijke ingang te beëindigen, voor zover dit gebeurt binnen 8 dagen na ontvangst van de prijswijziging.
+
+## Artikel 3 – Prijsherzieningsclausule
+
+3.1 Teneinde eventuele prijsschommelingen in materialen en grondstoffen op te vangen, bestaat bij elke overeenkomst de mogelijkheid om op schriftelijk verzoek de prijzen te herzien overeenkomstig de formule: P = p {a + (c × (l/i))}, waarbij: P = de nieuwe prijs; p = de oorspronkelijke prijs voorzien in de offerte; a = het percentage van de prijs dat niet voor herziening in aanmerking komt (a ≥ 0,20); c = het percentage van de materiaalkosten in de totale prijs (a + c = 1); l = de nieuwe materiaalindex (de maand voorafgaand aan de beëindiging van de werken); i = de oorspronkelijke materiaalindex (de maand voorafgaand aan de datum van de offerte). Als materiaalindex wordt gehanteerd: Index I 2021 (zie https://economie.fgov.be).
+
+3.2 Wanneer partijen overeenkomen dat de Klant de integrale kostprijs van de materialen voorschiet, dan geldt de toepassing van de herzieningsclausule tot aan ontvangst van dit voorschot. Vanaf dat ogenblik draagt STROOHM het risico van eventuele prijsstijgingen.
+
+## Artikel 4 – Leverings- en uitvoeringstermijnen
+
+4.1 Tenzij andersluidende schriftelijke overeenkomst, dienen de leverings- en uitvoeringstermijnen aanzien te worden als louter informatief. Zij zijn te goeder trouw doch bij benadering opgesteld. De geraamde termijnen gaan pas in van zodra STROOHM alle eventuele goedgekeurde plannen en/of alle andere documentatie die voor de uitvoering noodzakelijk is, heeft ontvangen.
+
+4.2 Alle vertragingen in uitvoering omwille van omstandigheden niet toerekenbaar aan STROOHM, hebben een opschorting van de verbintenissen in hoofde van STROOHM tot gevolg, waarbij de Klant afstand doet van enig recht op verhaal van schade. Hieronder worden onder meer begrepen: brand, staking, lock-out, ontploffingen, zware sneeuwval, overstromingen, machinebreuk, schaarste aan grondstoffen of werkkrachten, ongevallen, import- en exportbeperkingen.
+
+4.3 De Klant heeft het recht in geval van overmacht die gedurende 40 aaneengesloten dagen heeft aangehouden, de overeenkomst geheel of gedeeltelijk en met onmiddellijke ingang schriftelijk op te zeggen.
+
+4.4 Wijzigingen in de bestellingen betekenen automatisch dat de initieel vooropgestelde leverings- en uitvoeringstermijnen vervallen en het voorwerp zullen uitmaken van een aanpassing, zowel van prijs als van leveringstermijn.
+
+## Artikel 5 – Uitvoeringsmodaliteiten
+
+5.1 De Klant moet ervoor zorgen dat de werf normaal bereikbaar en toegankelijk is met voldoende manoeuvreer- en parkeergelegenheid, en dient de werf vrij te maken van eventuele obstakels. Er dient elektrische stroom voorzien te zijn, gratis ter beschikking gesteld door de Klant. De Klant bevestigt dat de elektrische installatie conform het AREI is.
+
+5.2 STROOHM staat niet in voor het ter beschikking stellen van een veiligheidscoördinator en/of asbestinventaris. De kosten die voortvloeien uit het niet respecteren van artikel 5.1. door de Klant, zullen aan de Klant worden doorgerekend.
+
+5.3 De aarding van de woning bevindt zich buiten de uitgevoerde werken van STROOHM, waardoor STROOHM nooit aansprakelijk is voor een afkeuring vanwege een niet-conforme aarding door de onafhankelijke keuringsinstantie.
+
+5.4 De prestaties van STROOHM worden hetzij door STROOHM zelf uitgevoerd, dan wel door een competente onderaannemer van STROOHM. STROOHM blijft in alle gevallen het aanspreekpunt voor de Klant.
+
+5.5 De Klant verbindt zich ertoe om, rechtstreeks of via een met hen verbonden vennootschap dan wel derden, geen activiteiten uit te oefenen die concurrerend zouden zijn met de prestaties/werken die door STROOHM worden geleverd, beperkt tot het grondgebied van de Benelux en gedurende drie jaar na de laatste werkzaamheden. Elke overtreding wordt gesanctioneerd met een forfaitaire schadevergoeding van 20.000,00 EUR.
+
+5.6 De Klant verbindt zich ertoe, tot drie jaar na de laatste werkzaamheden, geen personeelsleden van STROOHM, rechtstreeks of onrechtstreeks, te benaderen om ze in dienst te nemen. Elke overtreding wordt gesanctioneerd met een forfaitaire schadevergoeding van 20.000,00 EUR.
+
+## Artikel 6 – Het laadplatform en de rol van Monta
+
+6.1 STROOHM werkt voor de digitale beheersdiensten samen met Monta ApS als platformoperator. Het digitale laadplatform en de bijhorende mobiele applicatie worden rechtstreeks door Monta aan de Klant en eindgebruikers ter beschikking gesteld. Monta treedt hierbij op als zelfstandige contractpartij voor de Klant en eindgebruikers voor wat betreft het platformgebruik, de abonnementen en het energieverbruik.
+
+6.2 Abonnementen op het platform en het energieverbruik worden rechtstreeks door Monta aan de Klant gefactureerd, met het BTW-nummer van Monta. STROOHM is hierbij geen partij in de betalingsrelatie tussen Monta en de Klant.
+
+6.3 De eindgebruikers (EV-bestuurders) aanvaarden bij registratie de gebruiksvoorwaarden en het privacybeleid van Monta. Deze zijn raadpleegbaar via:
+- Monta Gebruiksvoorwaarden: https://app.monta.app/terms-and-conditions
+- Monta Privacybeleid: https://app.monta.app/privacy-policy
+
+6.4 STROOHM is niet aansprakelijk voor de werking, beschikbaarheid of wijzigingen van het Monta-platform, noch voor storingen in de platformdiensten of de facturen uitgestuurd door Monta. Voor klachten over het platform, de abonnementen of de energiefacturatie dient de Klant zich rechtstreeks tot Monta te richten.
+
+6.5 De Klant wordt erop gewezen dat stipte betaling van de facturatie van Monta noodzakelijk is. Vermits STROOHM verantwoordelijkheden draagt naar Monta, kunnen alle prestaties van zowel STROOHM als Monta worden opgeschort indien facturen van Monta meer dan 14 dagen na vervaldatum onbetaald blijven, zonder dat daarvoor een voorafgaande ingebrekestelling nodig is.
+
+## Artikel 7 – Eigendoms- en risico-overdracht
+
+7.1 De Klant wordt eigenaar van de door STROOHM geleverde en verwerkte koopwaar, installaties en materialen op het ogenblik dat de Klant aan alle betalingsverplichtingen ten aanzien van STROOHM heeft voldaan. Gelet op het eigendomsvoorbehoud is het de Klant verboden de verkochte koopwaar, installaties en materialen te vervreemden vóór algehele betaling.
+
+7.2 Vanaf de levering van de koopwaar, materialen en installaties door STROOHM aan de terreinen van de Klant, is het uitsluitend de Klant die instaat voor elk risico, gevallen van overmacht en geheel of gedeeltelijke vernietiging, verlies, diefstal, beschadiging of tenietgaan inbegrepen.
+
+## Artikel 8 – Gebreken en non-conformiteit
+
+8.1 STROOHM is gehouden om alle werken uit te voeren conform de overeenkomst en de regels van de goede kunst.
+
+8.2 Klachten betreffende zichtbare gebreken of niet-conformiteit dienen uiterlijk binnen de acht kalenderdagen na plaatsing schriftelijk te worden gemeld door de Klant aan STROOHM, bij gebreke waarvan de werken geacht worden te zijn aanvaard.
+
+8.3 Klachten betreffende verborgen gebreken dienen uiterlijk binnen de acht kalenderdagen na vaststelling aan STROOHM te worden gemeld. De aansprakelijkheid van STROOHM voor lichte verborgen gebreken is beperkt tot een termijn van twaalf (12) maanden na voltooiing van de werken, tenzij anders overeengekomen in de bijzondere voorwaarden of een garantieovereenkomst.
+
+8.4 De bewijslast van de beweerde verborgen gebreken berust bij de Klant. Elke aanspraak op vrijwaring vervalt bij verwerking, wijziging of herstel uit hoofde van de Klant of door hem aangestelde derden.
+
+## Artikel 9 – Aansprakelijkheid
+
+9.1 STROOHM is verbonden met de Klant door middel van een inspanningsverbintenis, tenzij uitdrukkelijk anders en schriftelijk overeengekomen.
+
+9.2 De bewaring van de werken geschiedt steeds op risico van de Klant.
+
+9.3 STROOHM is niet aansprakelijk indien de Klant niet heeft zorggedragen voor de vervaardiging van afschriften, veiligheidskopieën en andere dergelijke duplicaten van de aan STROOHM verstrekte bescheiden of tijdens de door STROOHM uitgevoerde werken, indien de vervaardiging daarvan redelijkerwijs van de Klant mocht worden gevergd.
+
+9.4 Beschadigingen tijdens de uitvoering van de werken aan ramen, deuren, muren, … die het gevolg zijn van het onzorgvuldig afschermen ervan door de Klant, kunnen niet ten laste vallen van STROOHM.
+
+9.5 De aansprakelijkheid van STROOHM bij bewezen aansprakelijkheid is in elk geval steeds beperkt tot het bedrag van de uitgevoerde werken. In geen geval kan volgende schade op STROOHM worden verhaald: indirecte schade, financieel en commercieel verlies, productieverlies, winstderving, verhoging van de algemene kosten, storing van de planning, verlies van cliënteel of aantasting van reputatie, schade die de Klant zou lijden ingevolge aanspraken van derden.
+
+9.6 STROOHM is niet aansprakelijk voor schade die voortvloeit uit de werking, beschikbaarheid of beveiliging van het Monta-platform, de platformabonnementen of de energiefacturatie door Monta.
+
+## Artikel 10 – Betalingsmodaliteiten
+
+10.1 De facturatie van de goederen en werken door STROOHM gebeurt als volgt, tenzij andersluidende schriftelijke afspraken: voorschotfactuur van 35% bij aanvaarding van de offerte (enkel indien het bedrag groter is dan € 4.000,00); een volgende voorschotfactuur van 35% één maand voor de aanvang der werken; het saldo van 30% nadat de installatie is afgerond, vóór de keuring.
+
+10.2 Behoudens andersluidend en schriftelijk akkoord zijn de facturen van STROOHM contant, netto en zonder korting of schuldvergelijking betaalbaar uiterlijk dertig (30) dagen na factuurdatum.
+
+10.3 Klachten betreffende de factuur dienen op straffe van verval binnen de acht (8) dagen na factuurdatum te gebeuren bij aangetekend en gemotiveerd schrijven, bij gebreke waarvan de factuur als aanvaard beschouwd wordt.
+
+10.4 In geval van laattijdige betaling zal op het factuurbedrag van rechtswege en zonder ingebrekestelling een verwijlintrest van 12% per jaar verschuldigd zijn, te rekenen vanaf de vervaldag. Bij gehele of gedeeltelijke niet-betaling wordt het schuldsaldo bij wijze van forfaitaire vergoeding verhoogd met 12% met een minimum van € 250. Gerechtskosten en invorderingskosten vallen ten laste van de Klant.
+
+10.5 Het uitblijven van betaling op de vervaldag maakt alle niet-vervallen facturen onmiddellijk opeisbaar en geeft STROOHM het recht verdere prestaties op te schorten.
+
+## Artikel 11 – Intellectuele eigendom en auteursrechten
+
+11.1 Alle door partijen aan elkaar verstrekte stukken, zoals rapporten, adviezen, overeenkomsten, ontwerpen, schetsen, tekeningen en software, zijn uitsluitend bestemd voor gebruik in het kader van deze overeenkomst en mogen niet worden verveelvoudigd, openbaar gemaakt of ter kennis van derden gebracht zonder voorafgaande toestemming van de andere partij.
+
+11.2 STROOHM behoudt het recht de door de uitvoering van de werkzaamheden verworven kennis voor andere doeleinden te gebruiken, voor zover hierbij geen vertrouwelijke informatie ter kennis van derden wordt gebracht.
+
+11.3 STROOHM heeft het recht tekeningen en foto's van de voor de Klant verrichte prestaties op haar website te vermelden, tijdens presentaties te vertonen of te vermelden bij andere commerciële toepassingen.
+
+## Artikel 12 – Gegevensbescherming
+
+12.1 STROOHM verwerkt persoonsgegevens van de Klant en diens contactpersonen als verwerkingsverantwoordelijke, uitsluitend voor de uitvoering van de overeenkomst, het klantenbeheer en de boekhouding. De STROOHM Privacyverklaring is raadpleegbaar via www.stroohm.com en wordt op verzoek bezorgd.
+
+12.2 De Klant heeft het recht inzage te vragen in zijn gegevens of ze te laten wijzigen/schrappen, via privacy@stroohm.com.
+
+12.3 Voor de verwerking van persoonsgegevens door Monta in het kader van het platform verwijst STROOHM naar het privacybeleid van Monta via https://app.monta.app/privacy-policy. Monta is hiervoor zelfstandig verwerkingsverantwoordelijke.
+
+## Artikel 13 – Overmacht
+
+13.1 Indien STROOHM haar verplichtingen niet, niet tijdig of niet behoorlijk kan nakomen ten gevolge van een niet aan haar toe te rekenen oorzaak — waaronder maar niet beperkt tot: oorlog, terrorisme, werkstaking, brand, milieu- en waterschade, overstroming, overheidsmaatregelen, storingen in de levering van energie, plotselinge arbeidsongeschiktheid van werknemers, of storingen in netwerken — worden die verplichtingen opgeschort tot STROOHM alsnog in staat is na te komen, zonder dat STROOHM in verzuim raakt of tot schadevergoeding kan worden gehouden.
+
+13.2 De Klant heeft het recht de overeenkomst schriftelijk op te zeggen indien de overmachtssituatie langer dan 40 aaneengesloten dagen aanhoudt.
+
+## Artikel 14 – Opschorting en buitengerechtelijke ontbinding
+
+14.1 Elke verbreking, opzegging of annulatie van een bestelling of contract, of het niet nakomen van de betalingsvoorwaarden of een andere wezenlijke wanprestatie, geeft de andere partij het recht haar verdere prestaties op te schorten.
+
+14.2 Een partij heeft het recht, wanneer artikel 14.1. van toepassing is en na schriftelijke ingebrekestelling, alle met de andere partij aangegane contracten als geheel of gedeeltelijk ontbonden te beschouwen, zonder rechterlijke tussenkomst en onverminderd het recht op schadevergoeding van minimaal 30% van de overeengekomen prijs.
+
+14.3 Indien in de loop van de uitvoering de financiële situatie van een partij zich dermate wijzigt dat gevreesd moet worden voor insolvabiliteit, heeft de andere partij na schriftelijke ingebrekestelling het recht de overeenkomst zonder rechterlijke tussenkomst te ontbinden.
+
+## Artikel 15 – Bevoegde rechtbank en toepasselijk recht
+
+15.1 Elke betwisting, van welke aard ook, zal worden beslecht door de territoriaal en materieel bevoegde rechtbank van de maatschappelijke zetel van STROOHM (arrondissement Antwerpen).
+
+15.2 Uitsluitend het Belgisch recht is van toepassing, met uitdrukkelijke uitsluiting van het Weens Koopverdrag van 11 april 1980.
+
+### Contactgegevens
+
+- **Naam:** STROOHM BV
+- **KBO-nummer:** 0716.755.863
+- **Adres:** Interescautlaan 100 bus 2.12, 2627 Schelle
+- **E-mail algemeen:** info@stroohm.com
+- **E-mail privacy:** privacy@stroohm.com
+- **Website:** www.stroohm.com
+
+_Deze Algemene Voorwaarden zijn voor het laatst bijgewerkt op 18 mei 2026._


### PR DESCRIPTION
## What

Updates Stroohm's **Terms & Conditions** and **Privacy Policy** to the 2026 versions supplied by the Stroohm team, and consolidates each into a **single multi-language document (English → French → Dutch)** with a jump-to-language Table of Contents at the top — following the existing Siemens multi-language pattern (`siemens-terms-and-conditions-2.md`).

| File | Before | After |
|------|--------|-------|
| `en-stroohm-terms-of-use.md` | English only (older version) | EN + FR + NL, 2026 version, ToC |
| `en-stroohm-privacy-policy.md` | English only (older version) | EN + FR + NL, 2026 version, ToC |

Filenames are kept unchanged so existing WL app / Hub URLs don't break.

## Why

Requested by the Stroohm team via Slack — both documents need to be live for the **white-label app and the Hub before 1 June 2026**. Stroohm asked whether the three languages could live in one document per type; this PR does exactly that (one Terms doc, one Privacy doc, each tri-lingual).

The other Stroohm-facing docs (AVG/privacy notice, Open Source, Toegankelijkheidsverklaring) are unchanged, as requested.

## Source

6 PDFs provided by the Stroohm team, all marked *last updated 18 May 2026*:
- General Terms & Conditions (EN / FR / NL)
- Privacy Policy / Déclaration de confidentialité / Privacyverklaring (EN / FR / NL)

Text is reproduced verbatim from the PDFs; only formatting was applied (headings, lists, GDPR tables) and the repeating PDF page footers were removed.

## Reviewer note — ToC anchors

The Table-of-Contents links use the same auto-generated anchor convention as the Siemens file, which strips non-ASCII characters (e.g. `für` → `fr`). The French section anchors therefore drop accents (e.g. `#stroohm-conditions-gnrales-franais`). **Please confirm the in-page jump links work in the actual Hub/app markdown renderer** — if that renderer keeps accents instead, the FR anchors will need adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)