### PR TITLE
chore: Update Monta GmbH Berlin address

### DIFF
--- a/de-academy-terms.md
+++ b/de-academy-terms.md
@@ -20,7 +20,7 @@ Diese Bedingungen werden regelmäßig aktualisiert. Die aktuellste Version finde
 
 &quot;Endnutzer&quot; bezeichnet den autorisierten und tatsächlichen Nutzer der Monta-Academy.
 
-&quot;Wir&quot;, &quot;uns&quot;, &quot;unser&quot; und &quot;Monta&quot; bedeutet Monta GmbH, Oranienstraße 10/11, 10997 Berlin, Deutschland, E-Mail: kontakt@monta.com, Amtsgericht Berlin HRB 167576 USt-IDdNr: DE347223826
+&quot;Wir&quot;, &quot;uns&quot;, &quot;unser&quot; und &quot;Monta&quot; bedeutet Monta GmbH, Monbijouplatz 4 10178 Berlin, Deutschland, E-Mail: kontakt@monta.com, Amtsgericht Berlin HRB 167576 USt-IDdNr: DE347223826
 
 &quot;Sie&quot; und &quot;Partner&quot; bezeichnet die Partei, die diesen Vertrag abschließt und am Academy-Partnerprogramm teilnimmt.
 

--- a/de-privacy-policy.md
+++ b/de-privacy-policy.md
@@ -1,6 +1,6 @@
 Monta Platform GmbH
-Oranienstraße 10/11
-10997 Berlin
+Monbijouplatz 4
+10178 Berlin
 Deutschland
 
 Amtsgericht Berlin HRB 167576


### PR DESCRIPTION
## Summary
Updates Monta GmbH's Berlin office address in the German documents from Oranienstraße 10/11, 10997 Berlin to Monbijouplatz 4, 10178 Berlin.

  ## Changes
  - `de-academy-terms.md` — updated address in party definition
  - `de-privacy-policy.md` — updated address in document header